### PR TITLE
fix: don't check cosign on prometheus-community charts

### DIFF
--- a/kubernetes/deploy/core/observability/prometheus-operator-crds/helmrelease.yaml
+++ b/kubernetes/deploy/core/observability/prometheus-operator-crds/helmrelease.yaml
@@ -12,11 +12,6 @@ spec:
   ref:
     tag: 19.0.0
   url: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
-  verify:
-    provider: cosign
-    matchOIDCIdentity:
-      - issuer: "^https://token.actions.githubusercontent.com$"
-        subject: "^https://github.com/prometheus-community/charts.*$"
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
The Prometheus community charts aren't signed it seems