### PR TITLE
chore: update scrape configs for kube scheduler and controller manager

### DIFF
--- a/kubernetes/deploy/core/observability/victoria-metrics/k8s-stack/helm/values.yaml
+++ b/kubernetes/deploy/core/observability/victoria-metrics/k8s-stack/helm/values.yaml
@@ -71,12 +71,42 @@ grafana:
       - hosts:
           - grafana-${CLUSTER_NAME}
 
+kubeControllerManager:
+  enabled: true
+  vmScrape:
+    spec:
+      jobLabel: jobLabel
+      namespaceSelector:
+        matchNames:
+          - kube-system
+      endpoints:
+        - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          port: http-metrics
+          scheme: https
+          tlsConfig:
+            # caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            # don't check cert since talos isn't using the k8s CA for this
+            insecureSkipVerify: true
+
 kubeEtcd:
   enabled: false
 
 kubeScheduler:
-  # -- Enable KubeScheduler metrics scraping
   enabled: true
+  vmScrape:
+    spec:
+      jobLabel: jobLabel
+      namespaceSelector:
+        matchNames:
+          - kube-system
+      endpoints:
+        - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          port: http-metrics
+          scheme: https
+          tlsConfig:
+            # caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            # don't check cert since talos isn't using the k8s CA for this
+            insecureSkipVerify: true
 
 kubeProxy:
   enabled: false


### PR DESCRIPTION
Out of the box Talos doesn't provide a cert to controller-manager or scheduler. https://github.com/siderolabs/talos/issues/9481#issuecomment-2416346949 The default config for these services generate it's own cert. For now ignore just the cert serving the metrics. 