### PR TITLE
feat: add gateway api via cilium v1.18.0-pre.1

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/apps/gateway/gateways.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gateway/gateways.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gateway
+  namespace: &namespace gateway
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  path: ./kubernetes/deploy/core/networking/gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m

--- a/kubernetes/clusters/fairy-k8s01/apps/gateway/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gateway/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gateway
+components:
+  - ../../../../components/common
+  - ../../../../components/flux-post-build-variables
+resources:
+  - ./gateways.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/kube-system/cilium-gw-config.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/kube-system/cilium-gw-config.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium-gateway-config
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  path: ./kubernetes/deploy/core/networking/cilium/gateway-config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m

--- a/kubernetes/clusters/fairy-k8s01/apps/kube-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/kube-system/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../../../components/flux-post-build-variables
 resources:
   - ./cilium.yaml
+  - ./cilium-gw-config.yaml
   - ./generic-device-plugin.yaml
   - ./intel-device-plugin.yaml
   - ./multus.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./external-dns
   - ./external-secrets
   - ./flux-system
+  - ./gateway
   - ./golink
   - ./home-automation
   - ./kube-system

--- a/kubernetes/deploy/core/flux/instance/helm/values.yaml
+++ b/kubernetes/deploy/core/flux/instance/helm/values.yaml
@@ -15,7 +15,7 @@ instance:
     url: https://github.com/nicolerenee/infra.git
     ref: refs/heads/main
     # path: kubernetes/clusters/${CLUSTER_NAME}/flux
-    interval: 1h
+    interval: 5m
   commonMetadata:
     labels:
       app.kubernetes.io/name: flux

--- a/kubernetes/deploy/core/networking/cilium/gateway-config/kustomization.yaml
+++ b/kubernetes/deploy/core/networking/cilium/gateway-config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tailscale-gwclass.yaml

--- a/kubernetes/deploy/core/networking/cilium/gateway-config/tailscale-gwclass.yaml
+++ b/kubernetes/deploy/core/networking/cilium/gateway-config/tailscale-gwclass.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumGatewayClassConfig
+metadata:
+  name: tailscale-gateway-config
+  namespace: kube-system
+spec:
+  service:
+    type: LoadBalancer
+    loadBalancerClass: tailscale
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: cilium-tailscale
+  namespace: kube-system
+spec:
+  controllerName: io.cilium/gateway-controller
+  description: Cilium GatewayClass with a Tailscale service
+  parametersRef:
+    group: cilium.io
+    kind: CiliumGatewayClassConfig
+    name: tailscale-gateway-config
+    namespace: kube-system

--- a/kubernetes/deploy/core/networking/gateway/certificate.yaml
+++ b/kubernetes/deploy/core/networking/gateway/certificate.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-domain-tls
+spec:
+  secretName: cluster-domain-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "${CLUSTER_DOMAIN}"
+  dnsNames:
+    - "${CLUSTER_DOMAIN}"
+    - "*.${CLUSTER_DOMAIN}"

--- a/kubernetes/deploy/core/networking/gateway/gw-media-mgmt.yaml
+++ b/kubernetes/deploy/core/networking/gateway/gw-media-mgmt.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gateway_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-media-mgmt
+
+spec:
+  gatewayClassName: cilium-tailscale
+  infrastructure:
+    annotations:
+      tailscale.com/hostname: ${CLUSTER_NAME:=cluster}-media-mgmt-gw
+      tailscale.com/tags: "tag:media-mgmt"
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.${CLUSTER_DOMAIN}"
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${CLUSTER_DOMAIN}"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: cluster-domain-tls

--- a/kubernetes/deploy/core/networking/gateway/gw-tailscale.yaml
+++ b/kubernetes/deploy/core/networking/gateway/gw-tailscale.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gateway_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tailscale
+
+spec:
+  gatewayClassName: cilium-tailscale
+  infrastructure:
+    annotations:
+      tailscale.com/hostname: ${CLUSTER_NAME:=cluster}-gw
+      tailscale.com/tags: "tag:${CLUSTER_NAME:=k8s}"
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.${CLUSTER_DOMAIN}"
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${CLUSTER_DOMAIN}"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: cluster-domain-tls

--- a/kubernetes/deploy/core/networking/gateway/kustomization.yaml
+++ b/kubernetes/deploy/core/networking/gateway/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./certificate.yaml
+  - ./gw-media-mgmt.yaml
+  - ./gw-tailscale.yaml
+  - ./redirect.yaml

--- a/kubernetes/deploy/core/networking/gateway/redirect.yaml
+++ b/kubernetes/deploy/core/networking/gateway/redirect.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpsredirect
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: none
+spec:
+  parentRefs:
+    - name: gw-tailscale
+      sectionName: http
+    - name: gw-media-mgmt
+      sectionName: http
+  rules:
+    - filters:
+        - requestRedirect:
+            scheme: https
+            statusCode: 301
+          type: RequestRedirect


### PR DESCRIPTION
Begin migration to gateway-api and moving away from nginx ingress since the project is entering maintenance mode. To be able to set the loadbalancerClass to Tailscale for the service cilium creates I need access to `CiliumGatewayClassConfig` which is only in cilium 1.18 which isn't released yet. The prerelease is manually pushed to the cluster and the ks/hr for cilium are frozen.