### PR TITLE
feat(tofu): plan-on-PR + apply-on-merge via GHA OIDC + WIF

### DIFF
--- a/.github/workflows/tofu.yaml
+++ b/.github/workflows/tofu.yaml
@@ -1,0 +1,87 @@
+name: tofu
+
+on:
+  pull_request:
+    paths: ['tofu/**', '.github/workflows/tofu.yaml']
+  push:
+    branches: [main]
+    paths: ['tofu/**', '.github/workflows/tofu.yaml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write       # required for GitHub Actions OIDC token
+  pull-requests: write  # for sticky plan comment
+
+env:
+  WIF_PROVIDER: projects/305363951351/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+  TOFU_RUNNER_SA: tofu-runner@freckle-iac-438712.iam.gserviceaccount.com
+
+jobs:
+  plan:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tofu
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.TOFU_RUNNER_SA }}
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: true
+
+      - run: tofu init -no-color
+
+      - id: plan
+        run: tofu plan -no-color -lock-timeout=2m
+        continue-on-error: true
+
+      - name: Post plan to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: tofu-plan
+          message: |
+            ### tofu plan — `${{ steps.plan.outcome }}`
+
+            <details><summary>Click to expand</summary>
+
+            ```hcl
+            ${{ steps.plan.outputs.stdout }}
+            ```
+
+            </details>
+
+            *Pusher: @${{ github.actor }} · Commit: ${{ github.sha }}*
+
+      - name: Fail if plan errored
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  apply:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tofu
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.TOFU_RUNNER_SA }}
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false   # not needed for apply
+
+      - run: tofu init -no-color
+
+      - run: tofu apply -auto-approve -no-color -lock-timeout=2m

--- a/.github/workflows/tofu.yaml
+++ b/.github/workflows/tofu.yaml
@@ -38,9 +38,26 @@ jobs:
 
       - run: tofu init -no-color
 
+      # Plan to a binary file so we can pretty-print just the diff
+      # without the "Refreshing state..." spam that leaks resource IDs
+      # into the PR comment / sticky-comment edit history.
       - id: plan
-        run: tofu plan -no-color -lock-timeout=2m
+        run: tofu plan -no-color -lock-timeout=2m -out=tfplan.binary
         continue-on-error: true
+
+      - id: plan-diff
+        if: steps.plan.outcome == 'success'
+        run: |
+          OUTPUT=$(tofu show -no-color tfplan.binary)
+          # Truncate so comment fits under GitHub's 65KB body limit
+          if [ ${#OUTPUT} -gt 60000 ]; then
+            OUTPUT="${OUTPUT:0:60000}"$'\n\n...[truncated; see workflow logs for full plan]'
+          fi
+          {
+            echo "diff<<TOFU_DIFF_EOF"
+            echo "$OUTPUT"
+            echo "TOFU_DIFF_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post plan to PR
         if: github.event_name == 'pull_request'
@@ -53,7 +70,7 @@ jobs:
             <details><summary>Click to expand</summary>
 
             ```hcl
-            ${{ steps.plan.outputs.stdout }}
+            ${{ steps.plan-diff.outputs.diff || steps.plan.outputs.stderr }}
             ```
 
             </details>

--- a/tofu/ci.tf
+++ b/tofu/ci.tf
@@ -1,0 +1,54 @@
+# GitHub Actions auth via Workload Identity Federation. The workflow
+# exchanges the action-run's OIDC token for a Google access token
+# representing the tofu-runner SA, then tofu proceeds exactly like local
+# dev.
+
+resource "google_iam_workload_identity_pool" "github_actions" {
+  workload_identity_pool_id = "github-actions"
+  display_name              = "GitHub Actions"
+  description               = "Pool for GitHub Actions OIDC identities used by CI/CD workflows"
+  project                   = local.iac_project
+
+  depends_on = [google_project_service.iac_apis]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github_actions" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-actions"
+  display_name                       = "GitHub Actions"
+  project                            = local.iac_project
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.ref"              = "assertion.ref"
+    "attribute.event_name"       = "assertion.event_name"
+  }
+
+  # Restrict to this repo. Loosen later if other repos need access.
+  attribute_condition = "assertion.repository == 'nicolerenee/infra'"
+}
+
+# Allow workflows from nicolerenee/infra to impersonate tofu-runner. Scoped
+# by repository (any branch); the workflow's trigger conditions gate which
+# actions get to run (PR=plan, push-to-main=apply).
+resource "google_service_account_iam_member" "tofu_runner_github_actions" {
+  service_account_id = "projects/${local.iac_project}/serviceAccounts/tofu-runner@${local.iac_project}.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.iac.number}/locations/global/workloadIdentityPools/github-actions/attribute.repository/nicolerenee/infra"
+}
+
+# Allow tofu-runner to impersonate itself, so the google provider's
+# impersonate_service_account=tofu-runner works in CI (where ADC is
+# already tofu-runner) without needing two different provider configs.
+resource "google_service_account_iam_member" "tofu_runner_self_impersonate" {
+  service_account_id = "projects/${local.iac_project}/serviceAccounts/tofu-runner@${local.iac_project}.iam.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:tofu-runner@${local.iac_project}.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Summary

- New `tofu/ci.tf` — WIF pool + provider for GitHub Actions OIDC, scoped to this repo. tofu-runner gets `serviceAccountTokenCreator` on itself so the existing `impersonate_service_account` provider config works in CI without env-specific branching.
- New `.github/workflows/tofu.yaml` — `plan` on PR (sticky comment), `apply` on push to main.

## Heads-up on the first PR run

The `tofu/ci.tf` resources don't exist in GCP yet — they're what this PR will create. So the workflow trying to authenticate to GCP using the GHA WIF provider will fail until someone runs `tofu apply` locally (or merges this PR with the bootstrap done first).

**Bootstrap sequence after merge:**

1. Locally: `cd tofu && tofu apply` (creates the WIF infrastructure)
2. Push any commit (or re-run the workflow) — CI now authenticates and runs end-to-end

Or alternatively: apply locally before merging; the PR's workflow then validates end-to-end before merging.

## Test plan

- [ ] Workflow file syntax is valid
- [ ] tofu plan locally shows 4 new resources to add (WIF pool, provider, two SA bindings)
- [ ] After local apply, the PR's plan job authenticates and posts a clean "no changes" comment
- [ ] After merge, apply job runs and shows no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)