### PR TITLE
feat(hedgehog): split deploy into migrate + workloads with dependsOn gate

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/hedgehog.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/hedgehog.yaml
@@ -1,7 +1,16 @@
 ---
-# App workloads — sourced from the OCI manifest bundle published by the
-# hedgehog repo. dependsOn ensures the OCIRepository, pull secret, and DB
-# all exist before the kustomize-controller tries to reconcile.
+# App workloads — sourced from the workloads subpath of the OCI manifest
+# bundle published by the hedgehog repo (ObjectBucketClaim + every
+# long-running Deployment + Service + HTTPRoute).
+#
+# `dependsOn: hedgehog-migrate` is the deploy-gate: Flux only reconciles
+# this Kustomization after the sibling `hedgehog-migrate` Kustomization
+# reaches Ready, which only happens once the migrate Job reports
+# `.status.succeeded` >= 1. If the migration fails, workload Deployments
+# stay at their prior reconciliation state — no rolling-update of serve /
+# worker / scheduler / kalshi-stream against an old schema. The other
+# dependsOn entries cover the platform OCIRepository + pull secret and the
+# CNPG database.
 # yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -20,11 +29,13 @@ spec:
       namespace: hedgehog
     - name: hedgehog-db
       namespace: hedgehog
+    - name: hedgehog-migrate
+      namespace: hedgehog
   sourceRef:
     kind: OCIRepository
     name: hedgehog
     namespace: hedgehog
-  path: ./
+  path: ./workloads
   interval: 5m
   retryInterval: 2m
   timeout: 5m

--- a/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./platform.yaml
   - ./db.yaml
   - ./queue.yaml
+  - ./migrate.yaml
   - ./hedgehog.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/migrate.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/migrate.yaml
@@ -1,0 +1,50 @@
+---
+# Database migration Kustomization — applies the migrate subpath of the
+# hedgehog OCI manifest bundle (ServiceAccount, both ExternalSecrets, and
+# the hedgehog-migrate Job).
+#
+# This Kustomization is the gate that keeps schema-mismatched rollouts out
+# of production. With `wait: true`, Flux reconciles this Kustomization as
+# Ready only after every applied resource is healthy — and for a Job, that
+# means `.status.succeeded` >= 1 (the migrate Job's `Complete` condition is
+# true). The sibling `hedgehog` Kustomization (workloads) has
+# `dependsOn: hedgehog-migrate`, so workload Deployments do NOT roll forward
+# until the migration succeeds. If the Job fails, Flux holds the workloads
+# Kustomization at its prior reconciliation state — no rolling-update of
+# serve / worker / scheduler / kalshi-stream against an old schema.
+#
+# The ExternalSecrets + ServiceAccount that workload pods reference are
+# owned by this Kustomization. Cross-Kustomization references in K8s are by
+# name+namespace, not by Flux ownership, so workload pods consume them
+# normally.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hedgehog-migrate
+  namespace: &namespace hedgehog
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  dependsOn:
+    - name: hedgehog-platform
+      namespace: hedgehog
+    - name: hedgehog-db
+      namespace: hedgehog
+  sourceRef:
+    kind: OCIRepository
+    name: hedgehog
+    namespace: hedgehog
+  path: ./migrate
+  interval: 5m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
## Summary

Splits the single outer Flux Kustomization that applies the hedgehog OCI manifest bundle into two — `hedgehog-migrate` (path `./migrate`) and `hedgehog` (path `./workloads`) — so workload Deployments don't roll forward past a failed migrate Job.

## Motivation — silent schema-mismatch risk

Today everything in the bundle applies in one outer Kustomization at `path: ./`. The migrate Job and the workload Deployments reconcile together. When the migrate Job fails, the rolling update of `serve` / `worker` / `scheduler` / `kalshi-stream` still proceeds with the old schema — silent corruption when application code expects new columns.

## The split (Option A — dependsOn)

The hedgehog manifest bundle already exposes two subpaths (`./migrate` + `./workloads`) — see `freckleapps/hedgehog/deploy/`. This PR consumes them from the infra side:

- `hedgehog-migrate` (new `migrate.yaml`, `path: ./migrate`) — ServiceAccount, both ExternalSecrets, and the migrate Job. `wait: true` makes Flux report this Kustomization Ready only when every applied resource is healthy; for a Job, that requires the `Complete` condition (`.status.succeeded >= 1`).
- `hedgehog` (existing `hedgehog.yaml`, now `path: ./workloads`) — every long-running Deployment + Service + HTTPRoute + the ObjectBucketClaim. Adds `dependsOn: hedgehog-migrate`.

Flux's `dependsOn` blocks reconciliation of the workloads Kustomization until the migrate Kustomization is Ready. Combined with `wait: true` on migrate, that's the deploy-gate: a failing migrate Job leaves the workloads Kustomization at its prior reconciliation state — no rolling update of pods against an old schema.

## What happens on migrate failure

- `flux get kustomization hedgehog-migrate -n hedgehog` shows `Ready=False`, reason = the Job failure (or a timeout if it hangs).
- `flux get kustomization hedgehog -n hedgehog` shows `Ready=Unknown / DependencyNotReady` — workloads stay on the previous image tag + previous manifest set.
- Operator unblocks by fixing the migration (e.g. follow-up migration, or `hedgehog migrate up --allow-missing` from a tools pod for the rare parallel-PR collision per the hedgehog runbook), then a fresh OCIRepository revision retriggers both Kustomizations.

## Test plan

- [x] `kustomize build kubernetes/clusters/atlantis-k8s01/apps/hedgehog/` succeeds and emits both Kustomizations (verified locally — `hedgehog-migrate` with `path: ./migrate`, `hedgehog` with `path: ./workloads` + `dependsOn: hedgehog-migrate`).
- [x] Verified hedgehog bundle layout: `freckleapps/hedgehog/deploy/{migrate,workloads}/` already exist with `kustomization.yaml` headers describing the consuming `hedgehog-migrate` + `hedgehog` Flux Kustomizations.
- [ ] CI passes (flux-local, kustomization-completeness, schema-validation).
- [ ] Post-merge: watch `flux get kustomization -n hedgehog` on atlantis-k8s01 to confirm both Kustomizations reconcile Ready, in the right order, on the next OCI revision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Flux reconciliation ordering for production deployments by introducing a `dependsOn` gate, which could block or delay workload rollouts if the migration Job fails or hangs. Otherwise it’s a configuration-only change scoped to the hedgehog app manifests.
> 
> **Overview**
> Splits hedgehog’s single Flux apply into two Kustomizations: **`hedgehog-migrate`** (applies `./migrate` with `wait: true`) and **`hedgehog`** (now applies only `./workloads`).
> 
> Adds `dependsOn: hedgehog-migrate` so long-running workloads only reconcile after the migration Job completes successfully, and wires the new `migrate.yaml` into the app-level `kustomization.yaml` resources list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076415290ab8c77846f2b394e7620faa90deb9f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->