### PR TITLE
revert(homebox): pin back to 0.25.0-hardened (0.26 needs API key pepper)

### DIFF
--- a/kubernetes/apps/homebox/homebox/helmrelease.yaml
+++ b/kubernetes/apps/homebox/homebox/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/sysadminsmedia/homebox
-              tag: 0.26.2-hardened
+              tag: 0.25.0-hardened
             env:
               # Logging
               HBOX_LOG_LEVEL: info


### PR DESCRIPTION
## Restores homebox — currently down

#1940 bumped homebox 0.25.0 → 0.26.2. **homebox 0.26.0 made `HBOX_AUTH_API_KEY_PEPPER` (≥32 bytes) a mandatory startup config.** Without it the API panics immediately:

```
panic: auth.api_key_pepper must be set to at least 32 bytes; ... provide via HBOX_AUTH_API_KEY_PEPPER
```

The new pod crash-looped, Helm scaled down the old ReplicaSet, and homebox went fully down. This reverts the tag to `0.25.0-hardened` (pre-pepper) to restore service.

## Follow-up to re-do the upgrade

To move to 0.26.x: generate a 32-byte pepper (`openssl rand -base64 48`), store it in 1Password, surface it via the homebox ExternalSecret, and inject `HBOX_AUTH_API_KEY_PEPPER` into the env. Note: rotating the pepper invalidates all issued homebox API keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-image tag rollback to a previously running version; no secret or routing changes in this diff.
> 
> **Overview**
> **Reverts the Homebox container image** from `0.26.2-hardened` to `0.25.0-hardened` in the Homebox `HelmRelease` to bring the app back up after a failed upgrade.
> 
> 0.26.x requires `HBOX_AUTH_API_KEY_PEPPER` (≥32 bytes) at startup; that value is not wired through `homebox-secrets` / env today, so the new pod crash-looped and the deployment went fully down. Rolling back the tag restores the last known-good image that does not enforce the pepper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18693c073a0c03421b43761521c84b33fe51ce48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->