### PR TITLE
fix(victoria-logs): guard audit-parser VRL merge for Vector 0.56

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
@@ -93,7 +93,9 @@ spec:
               - audit
             source: |
               parsed = parse_json(.message) ?? {}
-              . = merge(., parsed)
+              if is_object(parsed) {
+                . = merge(., parsed)
+              }
               del(.message)
               .log_source = "kube-apiserver-audit"
         sinks:


### PR DESCRIPTION
## Fixes crash-looping vector pods after #1881

victoria-logs-single **0.13.8 bundles Vector 0.56.0** (up from 0.55.0), which tightened VRL type checking. The `audit-parser` remap transform did:

```
parsed = parse_json(.message) ?? {}
. = merge(., parsed)
```

`parse_json` can return a non-object, so `merge(., parsed)` is now a **fallible assignment** (`error[E103]: unhandled fallible assignment`) and the vector config fails to compile — the new daemonset pods crash-loop (old 0.55.0 pods kept serving, so no log-collection outage).

Fix: guard the merge with `is_object(parsed)` so it's infallible. Behavior is identical for real kube-apiserver audit logs (always JSON objects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single VRL guard in observability log parsing; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes Vector 0.56 config compile failures** that crash-loop victoria-logs Vector pods after the chart upgrade.
> 
> The `audit-parser` remap now only runs `merge(., parsed)` when `is_object(parsed)` is true. Vector 0.56 treats `merge` with a non-object `parsed` (possible when `parse_json(.message)` does not return an object) as an unhandled fallible assignment. Real kube-apiserver audit lines stay JSON objects, so behavior for valid audit logs is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48a609b7dd9bc4c7bf2591fc403bdcef366a0e73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->