### PR TITLE
fix(victoria-logs): merge! in audit-parser (Vector 0.56 still crash-loops)

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
@@ -94,7 +94,7 @@ spec:
             source: |
               parsed = parse_json(.message) ?? {}
               if is_object(parsed) {
-                . = merge(., parsed)
+                . = merge!(., parsed)
               }
               del(.message)
               .log_source = "kube-apiserver-audit"


### PR DESCRIPTION
Follow-up to #1969. The `is_object` guard didn't satisfy Vector 0.56's VRL type checker — `merge(., parsed)` is still flagged `E103: unhandled fallible assignment` even inside the guard, so vector kept crash-looping. Switch to `merge!` (the guard guarantees parsed is an object, so it never aborts at runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line VRL change in log parsing only; behavior is unchanged when parsed JSON is an object as guarded.
> 
> **Overview**
> Updates the Victoria Logs **Vector** `audit-parser` remap transform to use **`merge!(., parsed)`** instead of **`merge(., parsed)`** when folding parsed JSON into the event.
> 
> Vector **0.56** still treats **`merge`** as fallible (`E103: unhandled fallible assignment`) even when **`parsed`** is only merged inside an **`is_object(parsed)`** guard, which kept **vector** crash-looping. **`merge!`** satisfies the type checker; with the guard, **`parsed`** is an object so the infallible merge should not abort at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55327fa780274b578919b07920dccc9c9f47bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->