### PR TITLE
chore(renovate): group cilium + prometheus-operator-crds into single PRs

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -23,9 +23,12 @@
       },
     },
     {
+      // Cilium is tracked from two datasources: the Flux OCIRepository
+      // (docker, quay.io/cilium/charts/cilium) and the bootstrap helmfile
+      // (helm, cilium/cilium). Match both so the chart + image bump as one PR.
       description: "Cilium Group",
       groupName: "Cilium",
-      matchDatasources: ["docker"],
+      matchDatasources: ["docker", "helm"],
       matchPackageNames: ["/cilium/"],
       group: {
         commitMessageTopic: "{{{groupName}}}",
@@ -75,6 +78,19 @@
       groupName: "Barman Cloud Plugin",
       matchDatasources: ["docker"],
       matchPackageNames: ["/plugin-barman-cloud/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}}",
+      },
+    },
+    {
+      // prometheus-operator-crds is tracked from two datasources: the Flux
+      // OCIRepository (docker, ghcr.io/prometheus-community/charts/...) and the
+      // bootstrap helmfile (helm, prometheus-community/prometheus-operator-crds).
+      // Match both so they bump together in one PR.
+      description: "Prometheus Operator CRDs Group",
+      groupName: "Prometheus Operator CRDs",
+      matchDatasources: ["docker", "helm"],
+      matchPackageNames: ["/prometheus-operator-crds/"],
       group: {
         commitMessageTopic: "{{{groupName}}}",
       },


### PR DESCRIPTION
Both cilium and prometheus-operator-crds are tracked from **two datasources**:
- the Flux `OCIRepository` (datasource `docker`), and
- the `bootstrap/helmfile.yaml` chart entry (datasource `helm`).

The existing Cilium group only matched `docker`, so the helm-chart bump came as a separate PR (e.g. #1945 + #1947). prometheus-operator-crds had no group at all (#1956 + #1957).

This broadens the Cilium group to `["docker", "helm"]` and adds an equivalent **Prometheus Operator CRDs** group, so each set bumps together in one PR going forward.

Takes effect on the next renovate run; existing split PRs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate grouping config only; no application or cluster runtime behavior changes.
> 
> **Overview**
> Renovate package rules in **`.renovate/groups.json5`** are updated so **Cilium** and **prometheus-operator-crds** version bumps from Flux OCI (`docker`) and bootstrap helmfile (`helm`) land in **one PR each** instead of split PRs.
> 
> The **Cilium** rule now uses `matchDatasources: ["docker", "helm"]` (previously `docker` only), with a short comment explaining the dual tracking. A new **Prometheus Operator CRDs** group mirrors that pattern for `/prometheus-operator-crds/` across both datasources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56207d9b86f134439029256f430494cc8e2a051c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->