### PR TITLE
chore(renovate): group mariadb + victoria-metrics operators with their CRDs

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -104,5 +104,34 @@
         commitMessageTopic: "{{{groupName}}}",
       },
     },
+    {
+      // mariadb-operator and mariadb-operator-crds are separate charts that
+      // must move in lockstep (the operator HelmRelease dependsOn the crds one).
+      // The /mariadb-operator/ regex matches both names.
+      description: "MariaDB Operator Group",
+      groupName: "MariaDB Operator",
+      matchDatasources: ["helm", "docker"],
+      matchPackageNames: ["/mariadb-operator/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}}",
+      },
+    },
+    {
+      // The victoria-metrics k8s-stack bundles the VM operator, whose version
+      // must match victoria-metrics-operator-crds (the stack dependsOn the crds
+      // chart). Group them so they always bump together. victoria-logs-single
+      // and victoria-traces-single are intentionally left out — they're
+      // independent single-binary charts with their own release cadence.
+      description: "VictoriaMetrics Stack Group",
+      groupName: "VictoriaMetrics Stack",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "/victoria-metrics-k8s-stack/",
+        "/victoria-metrics-operator-crds/",
+      ],
+      group: {
+        commitMessageTopic: "{{{groupName}}}",
+      },
+    },
   ],
 }


### PR DESCRIPTION
Follows the same operator/CRDs coupling as the cilium + prometheus-operator-crds grouping (#1971).

- **MariaDB Operator**: `mariadb-operator` + `mariadb-operator-crds` are separate helm charts; the operator HelmRelease `dependsOn` the crds one, so they must move in lockstep (e.g. #1909 + #1910 → one PR).
- **VictoriaMetrics Stack**: `victoria-metrics-k8s-stack` bundles the VM operator, whose version must match `victoria-metrics-operator-crds` (the stack `dependsOn` the crds chart). These came as separate PRs this session (#1882 + #1936). `victoria-logs-single` / `victoria-traces-single` are intentionally left independent.

Takes effect next renovate run; existing split PRs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate configuration only; no cluster manifests or application logic are modified.
> 
> **Overview**
> Adds two **Renovate package rules** in `.renovate/groups.json5` so coupled operator/CRD bumps land in a single PR instead of separate ones.
> 
> **MariaDB Operator** groups anything matching `/mariadb-operator/` across **helm** and **docker** datasources (covers `mariadb-operator` and `mariadb-operator-crds`, which share versions and where the operator HelmRelease `dependsOn` the CRDs release).
> 
> **VictoriaMetrics Stack** groups `victoria-metrics-k8s-stack` with `victoria-metrics-operator-crds` on **docker** only; `victoria-logs-single` and `victoria-traces-single` stay ungrouped.
> 
> Behavior matches existing patterns (e.g. Cilium, Prometheus Operator CRDs). Rules apply on the next Renovate run; open split PRs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b764372e567ccfd59dcb341d361164d0e158f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->