### PR TITLE
feat(homebox): wire HBOX_AUTH_API_KEY_PEPPER for 0.26 upgrade

### DIFF
--- a/kubernetes/apps/homebox/homebox/externalsecret.yaml
+++ b/kubernetes/apps/homebox/homebox/externalsecret.yaml
@@ -11,6 +11,9 @@ spec:
   target:
     template:
       data:
+        # Homebox auth (required >= 0.26.0; >=32 bytes, openssl rand -base64 48).
+        # Rotating this invalidates all issued homebox API keys.
+        HBOX_AUTH_API_KEY_PEPPER: "{{ .HBOX_AUTH_API_KEY_PEPPER }}"
         # Homebox PostgreSQL connection
         HBOX_DATABASE_DRIVER: postgres
         HBOX_DATABASE_HOST: pg-17a-rw.db.svc.cluster.local


### PR DESCRIPTION
Prereq for the homebox 0.26.x bump (#1968 / previously reverted #1967).

homebox 0.26.0 made `HBOX_AUTH_API_KEY_PEPPER` (≥32 bytes) mandatory. The pepper has been generated (`openssl rand -base64 48`) and stored in the `homebox-atlantis-k8s01` 1Password item. This maps it into the `homebox-secrets` secret via the ExternalSecret `template.data` (the template uses the default Replace mergePolicy, so raw `dataFrom` keys don't auto-surface — they must be listed explicitly).

**Order:** merge + reconcile this first, confirm the secret has the key, *then* the image bump #1968 is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication configuration; a bad or missing pepper would break API key validation after the 0.26 upgrade, though the change is additive and isolated to secret templating.
> 
> **Overview**
> Adds **`HBOX_AUTH_API_KEY_PEPPER`** to the `homebox-secrets` ExternalSecret `template.data`, sourced from the existing 1Password `dataFrom` extract via `{{ .HBOX_AUTH_API_KEY_PEPPER }}`. Comments note the ≥32-byte requirement for Homebox **≥0.26.0** and that rotating the pepper invalidates issued API keys.
> 
> This is the deploy-order prerequisite so the Kubernetes secret contains the mandatory auth env var **before** bumping the Homebox image to 0.26.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e431906f9e2542b03fd25126f94855661f5dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->