### PR TITLE
feat(mariadb): set autoUpdateDataPlane (prereq for operator 26.6)

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/db/mariadb-clusters/mariadb-main.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/db/mariadb-clusters/mariadb-main.yaml
@@ -10,6 +10,11 @@ spec:
 
   image: mariadb:12.2.2
 
+  # Required by the mariadb-operator 26.6 upgrade guide: let the operator roll
+  # the data-plane (agent) in lockstep when it upgrades, instead of lagging.
+  updateStrategy:
+    autoUpdateDataPlane: true
+
   port: 3306
 
   storage:


### PR DESCRIPTION
Prereq for #1973 (mariadb-operator 26.3→26.6).

The [26.6.0 upgrade guide](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_26.6.0.md) requires `updateStrategy.autoUpdateDataPlane: true` on MariaDB CRs **before** bumping the operator, so the operator rolls the data-plane (agent sidecar) to 26.6 in lockstep rather than letting it lag.

Merge + reconcile this first (sets the field, no restart), then #1973 (operator → rolls the single-instance `mariadb-main` data-plane), then #1897 (engine 12.2.2→12.3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CR field addition with no engine or operator version change in this PR; intended as a no-restart prerequisite before a separate operator upgrade.
> 
> **Overview**
> Adds **`spec.updateStrategy.autoUpdateDataPlane: true`** on the `mariadb-main` MariaDB CR so the mariadb-operator can roll the data-plane (agent sidecar) together with operator upgrades, per the 26.6.0 upgrade guide.
> 
> This is a **prerequisite** step before bumping the operator to 26.6 (#1973); the PR description notes reconcile should set the field without restarting the instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195ba80f9952f7479004a3fc6dbf5eba38cee4d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->