### PR TITLE
fix(hedgehog): pin Dragonfly v1.37.0 (v1.39 can't load snapshot)

### DIFF
--- a/kubernetes/apps/hedgehog/queue/dragonfly.yaml
+++ b/kubernetes/apps/hedgehog/queue/dragonfly.yaml
@@ -11,6 +11,11 @@ metadata:
   name: hedgehog-queue
 spec:
   replicas: 3
+  # Pin the Dragonfly version: the operator's default image bumped to v1.39.0,
+  # which fails to load v1.37-written RDB snapshots ("Quicklist integrity check
+  # failed"), crash-looping the primary. Stay on v1.37.0 until a snapshot-safe
+  # upgrade path is validated.
+  image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.37.0
   authentication:
     passwordFromSecret:
       name: hedgehog-queue-secrets


### PR DESCRIPTION
dragonfly-operator 1.6.1 (#1935) bumped the default data-plane image to v1.39.0. The queue primary's v1.37-written RDB snapshot fails to load under v1.39 (`Quicklist integrity check failed`), crash-looping hedgehog-queue-0. Pin to v1.37.0 so the persisted HA queue loads. Operator stays at 1.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the persisted HA job queue backing hedgehog workers; pinning avoids outage but defers a needed version upgrade path.
> 
> **Overview**
> Pins the **hedgehog-queue** Dragonfly data plane to `docker.dragonflydb.io/dragonflydb/dragonfly:v1.37.0` so the cluster no longer picks up the operator’s newer default (**v1.39.0**).
> 
> After the operator default moved to v1.39, the primary could not load RDB snapshots written under v1.37 (`Quicklist integrity check failed`), which crash-looped **hedgehog-queue-0** and broke the persisted HA job queue. The manifest comment documents staying on v1.37 until a snapshot-safe upgrade is validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32bc4286f57f8e58cd751fc447568abdae8a42b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->