### PR TITLE
chore(hedgehog): unpin Dragonfly image (follow operator default)

### DIFF
--- a/kubernetes/apps/hedgehog/queue/dragonfly.yaml
+++ b/kubernetes/apps/hedgehog/queue/dragonfly.yaml
@@ -11,11 +11,6 @@ metadata:
   name: hedgehog-queue
 spec:
   replicas: 3
-  # Pin the Dragonfly version: the operator's default image bumped to v1.39.0,
-  # which fails to load v1.37-written RDB snapshots ("Quicklist integrity check
-  # failed"), crash-looping the primary. Stay on v1.37.0 until a snapshot-safe
-  # upgrade path is validated.
-  image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.37.0
   authentication:
     passwordFromSecret:
       name: hedgehog-queue-secrets


### PR DESCRIPTION
Reverts the v1.37.0 pin from #1976. That crash was a corrupt snapshot on queue-0 (failed on both v1.37 and v1.39), not a version incompatibility — queue-1/2 ran fine on v1.39. queue-0 has since been reset and resynced clean, so removing the pin lets operator upgrades carry the engine version as expected. The operator (1.6.1) will roll all 3 replicas to its default (v1.39.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted HA job-queue infrastructure and triggers a coordinated engine version rollout; prior outage was attributed to a bad snapshot on one replica rather than version skew.
> 
> **Overview**
> Removes the explicit **Dragonfly v1.37.0** image pin on `hedgehog-queue`, so the Dragonfly operator (1.6.1) again chooses the default engine image (expected **v1.39.0**) and can move versions on operator upgrades without a manual override.
> 
> This reverses the temporary pin from #1976; the related comment about v1.39 failing on v1.37-written RDB snapshots is dropped with the `spec.image` field. A full rollout across the three HA replicas is implied once the manifest reconciles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e0f9a0e5065681ed782f35439cb3af1185f614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->