### PR TITLE
feat(rook): upgrade to v1.20.1 + ceph-csi-drivers (Ceph→Tentacle), atlantis-staged

### DIFF
--- a/kubernetes/apps/storage/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/cluster/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.1
   url: oci://ghcr.io/rook/rook-ceph-cluster
 ---
 # yaml-language-server: $schema=https://k8s-schemas.freckle.systems/helm.toolkit.fluxcd.io/helmrelease_v2.json

--- a/kubernetes/apps/storage/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/csi-drivers/helmrelease.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+spec:
+  interval: 24h
+  url: https://ceph.github.io/ceph-csi-operator
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rook-ceph-csi-drivers
+spec:
+  interval: 30m
+  timeout: 15m
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      version: 1.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  # Rook v1.20 moved CSI driver management to the ceph-csi-operator. This chart
+  # authors the OperatorConfig/Driver CRs. Values restore the behavior we had
+  # under the rook-ceph operator chart's (now-removed) inline csi.* block.
+  values:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+          # CSI node plugins must schedule on GPU-tainted nodes (was csi.pluginTolerations).
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+          # Preserve old enableCSIHostNetwork=true (chart default flipped to false).
+          hostNetwork: true
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+        # Chart default is "none"; restore snapshotter so volsync RBD snapshots work.
+        snapshotPolicy: volumeSnapshot
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        # Chart default flipped to "None"; restore prior "File" behavior.
+        fsGroupPolicy: File
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com

--- a/kubernetes/apps/storage/rook-ceph/csi-drivers/kustomization.yaml
+++ b/kubernetes/apps/storage/rook-ceph/csi-drivers/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/storage/rook-ceph/operator/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/operator/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.1
   url: oci://ghcr.io/rook/rook-ceph
 ---
 # yaml-language-server: $schema=https://k8s-schemas.freckle.systems/helm.toolkit.fluxcd.io/helmrelease_v2.json
@@ -36,11 +36,10 @@ spec:
     - name: prometheus-operator-crds
       namespace: observability
   values:
+    # v1.20: CSI is managed by the ceph-csi-operator (installed by this chart via
+    # installCsiOperator, default true). Driver config (incl. the nvidia.com/gpu
+    # node-plugin toleration) now lives in the ceph-csi-drivers HelmRelease.
     csi:
-      pluginTolerations:
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: NoSchedule
       serviceMonitor:
         enabled: true
     monitoring:

--- a/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../../../components/flux-post-build-variables
 resources:
   - ./rook-ceph.yaml
+  - ./rook-ceph-csi-drivers.yaml
   - ./rook-ceph-cluster.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   targetNamespace: *namespace
   dependsOn:
-    - name: rook-ceph
+    - name: rook-ceph-csi-drivers
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-csi-drivers.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-csi-drivers.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-csi-drivers
+  namespace: &namespace rook-ceph
+spec:
+  targetNamespace: *namespace
+  dependsOn:
+    - name: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/storage/rook-ceph/csi-drivers
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 2m
+  retryInterval: 1m
+  timeout: 15m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     infra.freckle.systems/post-build-variables: enabled
 spec:
+  # STAGED: hold fairy on rook v1.19.6 until atlantis v1.20 is verified, then unsuspend + wire csi-drivers.
+  suspend: true
   targetNamespace: *namespace
   dependsOn:
     - name: rook-ceph

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &app rook-ceph
   namespace: &namespace rook-ceph
 spec:
+  # STAGED: hold fairy on rook v1.19.6 until atlantis v1.20 is verified, then unsuspend + wire csi-drivers.
+  suspend: true
   targetNamespace: *namespace
   dependsOn:
     - name: prometheus-operator-crds


### PR DESCRIPTION
Supersedes the plain bump in #1901. Upgrades Rook-Ceph v1.19.6 → **v1.20.1**, which migrates CSI to the ceph-csi-operator model and (intentionally, via our unpinned cephVersion) moves Ceph **Squid v19.2.3 → Tentacle v20.2.1**.

## Why this isn't a plain tag bump
v1.20 removed the operator chart's inline `csi.*` block and delegates CSI to the **ceph-csi-operator** (bundled subchart) + a **mandatory new `ceph-csi-drivers` chart** that authors the `OperatorConfig`/`Driver` CRs. Without it, CSI fails (missing service accounts). It also silently changed several defaults.

## What this PR does
- **New `ceph-csi-drivers` HelmRelease** (`apps/storage/rook-ceph/csi-drivers/`, chart 1.0.1 from ceph.github.io/ceph-csi-operator) restoring our prior behavior:
  - `nodePlugin.tolerations: [nvidia.com/gpu]` — was `csi.pluginTolerations` (CSI must schedule on GPU-tainted nodes)
  - `drivers.rbd.snapshotPolicy: volumeSnapshot` — **chart default is `none`**; required or volsync RBD snapshots break
  - `drivers.cephfs.fsGroupPolicy: File` — chart flipped default to `None`
  - `controllerPlugin.hostNetwork: true` — chart flipped default to `false` (was `enableCSIHostNetwork: true`)
  - priorityClassNames (system-node-critical / system-cluster-critical); nfs/nvmeof disabled
- **Operator chart → v1.20.1**; drop dead `csi.pluginTolerations`; keep `csi.serviceMonitor.enabled` + `monitoring.enabled`.
- **Cluster chart → v1.20.1** (Ceph default → Tentacle v20.2.1, the upgrade we want; v20.2.0's read-affinity bug is avoided).
- **Flux wiring (atlantis):** new `rook-ceph-csi-drivers` KS between operator and cluster (operator → csi-drivers → cluster).
- **Staging:** fairy's rook KSs are **suspended** in git so only atlantis rolls. After atlantis is verified, a follow-up unsuspends fairy + adds its csi-drivers wiring.

Upgrade order per Rook docs: rook-ceph (operator) → ceph-csi-drivers → rook-ceph-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cluster storage CSI provisioning, Rook/Ceph major-version upgrade path, and ordered Flux rollout; misconfiguration or ordering could break volumes, snapshots, or the Ceph upgrade on atlantis.
> 
> **Overview**
> Upgrades Rook operator and cluster Helm charts from **v1.19.6** to **v1.20.1**, which moves CSI out of the operator chart and (with unpinned `cephVersion`) drives a Ceph **Squid → Tentacle** cluster upgrade on clusters that apply the cluster chart.
> 
> Adds a new **`ceph-csi-drivers`** HelmRelease (chart 1.0.1) so `OperatorConfig`/`Driver` CRs exist after v1.20; values intentionally override new chart defaults: GPU node-plugin tolerations, RBD `volumeSnapshot` snapshot policy (volsync), CephFS `fsGroupPolicy: File`, and CSI controller `hostNetwork: true`. The operator release drops the old inline `csi.pluginTolerations` block and keeps monitoring-related CSI settings.
> 
> On **atlantis**, Flux now deploys **operator → csi-drivers → cluster** (`rook-ceph-csi-drivers` KS and cluster `dependsOn` updated). **fairy** rook operator and cluster Flux Kustomizations are **suspended** so only atlantis rolls until v1.20 is verified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbfd4ef831e6a613442ea3073a47b6130b222e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->