### PR TITLE
feat(rook): roll fairy to v1.20.1 + Ceph Tentacle (+ per-driver GPU toleration fix)

### DIFF
--- a/kubernetes/apps/storage/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/csi-drivers/helmrelease.yaml
@@ -56,11 +56,27 @@ spec:
         name: rook-ceph.rbd.csi.ceph.com
         # Chart default is "none"; restore snapshotter so volsync RBD snapshots work.
         snapshotPolicy: volumeSnapshot
+      nodePlugin:
+        # Per-driver toleration: the chart renders Driver CRs with an empty
+        # tolerations list which overrides driverSpecDefaults, so the GPU
+        # toleration must be set here too (fairy DGX nodes carry nvidia.com/gpu).
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
         # Chart default flipped to "None"; restore prior "File" behavior.
         fsGroupPolicy: File
+      nodePlugin:
+        # Per-driver toleration: the chart renders Driver CRs with an empty
+        # tolerations list which overrides driverSpecDefaults, so the GPU
+        # toleration must be set here too (fairy DGX nodes carry nvidia.com/gpu).
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
       nfs:
         enabled: false
         name: rook-ceph.nfs.csi.ceph.com

--- a/kubernetes/apps/storage/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/csi-drivers/helmrelease.yaml
@@ -41,11 +41,6 @@ spec:
           name: rook-csi-operator-image-set-configmap
         nodePlugin:
           priorityClassName: system-node-critical
-          # CSI node plugins must schedule on GPU-tainted nodes (was csi.pluginTolerations).
-          tolerations:
-            - key: nvidia.com/gpu
-              operator: Exists
-              effect: NoSchedule
         controllerPlugin:
           priorityClassName: system-cluster-critical
           # Preserve old enableCSIHostNetwork=true (chart default flipped to false).
@@ -56,27 +51,24 @@ spec:
         name: rook-ceph.rbd.csi.ceph.com
         # Chart default is "none"; restore snapshotter so volsync RBD snapshots work.
         snapshotPolicy: volumeSnapshot
-      nodePlugin:
-        # Per-driver toleration: the chart renders Driver CRs with an empty
-        # tolerations list which overrides driverSpecDefaults, so the GPU
-        # toleration must be set here too (fairy DGX nodes carry nvidia.com/gpu).
-        tolerations:
-          - key: nvidia.com/gpu
-            operator: Exists
-            effect: NoSchedule
+        nodePlugin:
+          # CSI node plugins must schedule on GPU-tainted nodes (fairy DGX nodes).
+          # Set per-driver: the Driver CR's empty tolerations list overrides
+          # operatorConfig.driverSpecDefaults, so it must be specified here.
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
         # Chart default flipped to "None"; restore prior "File" behavior.
         fsGroupPolicy: File
-      nodePlugin:
-        # Per-driver toleration: the chart renders Driver CRs with an empty
-        # tolerations list which overrides driverSpecDefaults, so the GPU
-        # toleration must be set here too (fairy DGX nodes carry nvidia.com/gpu).
-        tolerations:
-          - key: nvidia.com/gpu
-            operator: Exists
-            effect: NoSchedule
+        nodePlugin:
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
       nfs:
         enabled: false
         name: rook-ceph.nfs.csi.ceph.com

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../../../components/flux-post-build-variables
 resources:
   - ./rook-ceph.yaml
+  - ./rook-ceph-csi-drivers.yaml
   - ./rook-ceph-cluster.yaml
 patches:
   - target:

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
@@ -8,11 +8,9 @@ metadata:
   labels:
     infra.freckle.systems/post-build-variables: enabled
 spec:
-  # STAGED: hold fairy on rook v1.19.6 until atlantis v1.20 is verified, then unsuspend + wire csi-drivers.
-  suspend: true
   targetNamespace: *namespace
   dependsOn:
-    - name: rook-ceph
+    - name: rook-ceph-csi-drivers
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph-csi-drivers.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph-csi-drivers.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-csi-drivers
+  namespace: &namespace rook-ceph
+spec:
+  targetNamespace: *namespace
+  dependsOn:
+    - name: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/storage/rook-ceph/csi-drivers
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 2m
+  retryInterval: 1m
+  timeout: 15m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/rook-ceph.yaml
@@ -6,8 +6,6 @@ metadata:
   name: &app rook-ceph
   namespace: &namespace rook-ceph
 spec:
-  # STAGED: hold fairy on rook v1.19.6 until atlantis v1.20 is verified, then unsuspend + wire csi-drivers.
-  suspend: true
   targetNamespace: *namespace
   dependsOn:
     - name: prometheus-operator-crds


### PR DESCRIPTION
Second half of the rook v1.20 upgrade (after #1980 proved it on atlantis). Unsuspends fairy's rook and wires its ceph-csi-drivers, taking fairy from rook v1.19.6/Ceph Squid → **v1.20.1/Ceph Tentacle v20.2.1**.

Also a **shared fix**: set the `nvidia.com/gpu` node-plugin toleration **per-driver** (rbd + cephfs). On atlantis the Driver CR's empty `tolerations: []` overrode `operatorConfig.driverSpecDefaults`, so the toleration never reached the DS. Atlantis has no GPU taints so it was latent there — but **fairy's DGX nodes (`fairy-r02-dgx01/02/03`) carry `nvidia.com/gpu`**, so CSI node plugins must tolerate it or they won't run on the DGX nodes. This fix also corrects atlantis.

- Shared `ceph-csi-drivers` values: per-driver `nodePlugin.tolerations` for rbd + cephfs.
- Fairy: new `rook-ceph-csi-drivers` KS (operator → csi-drivers → cluster), added to kustomization, cluster KS `dependsOn` repointed.
- Fairy rook KSs **unsuspended** (removes the staging hold from #1980).

Atlantis verified before this: all 17 Ceph daemons on Tentacle, HEALTH_OK, all PVCs Bound, CSI drivers healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major storage stack upgrade on fairy (Rook/Ceph + CSI wiring) with cluster-wide impact if CSI node plugins or the upgrade fail on GPU-tainted nodes.
> 
> **Overview**
> **Fairy** is taken off the staged Rook hold: Flux `suspend: true` is removed from the operator and cluster Kustomizations, and a new **`rook-ceph-csi-drivers`** Kustomization is added so the deploy order is operator → CSI drivers → cluster (cluster `dependsOn` now targets CSI drivers).
> 
> The shared **`ceph-csi-drivers`** Helm values move **`nvidia.com/gpu`** node-plugin tolerations from `operatorConfig.driverSpecDefaults` to **per-driver** `rbd` and `cephfs` `nodePlugin` blocks, because an empty tolerations list on the Driver CR overrides defaults—required for GPU-tainted DGX nodes on fairy and to fix the same latent gap on atlantis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044ac85e5250a6ff723742e6a6a0adfb8351283a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->