### PR TITLE
fix(fairy/cilium): commit bpf.vlanBypass[300] to gitops

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/apps/kube-system/cilium.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/kube-system/cilium.yaml
@@ -39,6 +39,16 @@ spec:
               preallocateMaps: true
               distributedLRU:
                 enabled: true
+              # VLAN 300 (home LAN) is bridged onto br300 via bond0.300
+              # for KubeVirt VMs and macvlan-style pods (scrypted,
+              # esphome). Cilium's TCX program on bond0 drops VLAN-tagged
+              # ingress with "VLAN traffic disallowed by VLAN filter"
+              # unless the VLAN is in this bypass list. Auto-detection
+              # only registers VLAN sub-interfaces that have an IP at
+              # agent startup, which is fragile; explicit bypass is
+              # the durable fix.
+              vlanBypass:
+                - 300
             loadBalancer:
               algorithm: maglev
             bpfClockProbe: true


### PR DESCRIPTION
Brings the live fairy cilium config into gitops. `bpf.vlanBypass: [300]` was applied directly to the fairy cilium HelmRelease (live `cilium-config` has `vlan-bpf-bypass: 300`) to fix VLAN-300 ingress — Cilium's TCX program on `bond0` drops VLAN-tagged traffic (KubeVirt VMs, scrypted/esphome macvlan pods on `br300`) unless the VLAN is in the bypass list. The cilium KS was suspended to stop Flux reverting it; this commits the fix so it can be **unsuspended safely** (and pick up the 1.19.5 chart bump from #1945 that atlantis already has).

Fairy-specific by location (`clusters/fairy-k8s01/`). After merge: unsuspend the fairy cilium KS and let it reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Cilium BPF/datapath VLAN filtering on the node uplink; misconfiguration could break or widen VLAN handling for home-LAN workloads, though this mirrors an already-working live setting.
> 
> **Overview**
> Commits the **fairy-k8s01** Cilium Helm values patch so **`bpf.vlanBypass: [300]`** is managed by Flux instead of a live-only edit. VLAN 300 (home LAN on `br300` / `bond0.300`) is used for KubeVirt VMs and macvlan-style workloads; without bypass, Cilium’s TCX on `bond0` drops tagged ingress with *VLAN traffic disallowed by VLAN filter*.
> 
> Inline comments document why explicit bypass is preferred over auto-detection at agent startup. After merge, the suspended fairy Cilium Kustomization can be unsuspended so GitOps matches cluster state and can pick up chart updates (e.g. 1.19.5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26167720255f5283294617be22714b7d09f47eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->