### PR TITLE
feat(janet): UI build bump + enable autonomous agentic tasks

### DIFF
--- a/kubernetes/apps/janet/brain/deployment.yaml
+++ b/kubernetes/apps/janet/brain/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             # Registers schedule_agentic_task and lets agentic fires run their
             # instruction, gated by the intent judge (JANET_JUDGE_MODEL=fast via
             # the gateway). Judge fails closed — denies all if it can't reach its
-            # model — so the gateway fast route must be healthy (it is).
+            # model — so the gateway fast route must be healthy.
             - name: JANET_AGENTIC_ENABLED
               value: "true"
             # Keyless: the AI gateway holds the real Anthropic key. The

--- a/kubernetes/apps/janet/brain/deployment.yaml
+++ b/kubernetes/apps/janet/brain/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: janet-brain
-          image: ghcr.io/freckleapps/janet-brain:main-20260617T044026Z-46dde36
+          image: ghcr.io/freckleapps/janet-brain:main-20260624T015822Z-1e2561a
           ports:
             - name: http
               containerPort: 8787
@@ -49,6 +49,12 @@ spec:
               value: chat
             - name: JANET_JUDGE_MODEL
               value: fast
+            # Registers schedule_agentic_task and lets agentic fires run their
+            # instruction, gated by the intent judge (JANET_JUDGE_MODEL=fast via
+            # the gateway). Judge fails closed — denies all if it can't reach its
+            # model — so the gateway fast route must be healthy (it is).
+            - name: JANET_AGENTIC_ENABLED
+              value: "true"
             # Keyless: the AI gateway holds the real Anthropic key. The
             # placeholder only satisfies the SDK's credential precondition;
             # the gateway overrides whatever the client sends.

--- a/kubernetes/apps/janet/migrate/migrate-job.yaml
+++ b/kubernetes/apps/janet/migrate/migrate-job.yaml
@@ -37,7 +37,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: ghcr.io/freckleapps/janet-brain:main-20260617T040930Z-dc58d35
+          image: ghcr.io/freckleapps/janet-brain:main-20260624T015822Z-1e2561a
           args: ["migrate", "up"]
           envFrom:
             # DATABASE_URL (managed janet role on the dedicated cluster).


### PR DESCRIPTION
Two coupled janet changes:

**1. Bump to the new UI build** — `ghcr.io/freckleapps/janet-brain:main-20260624T015822Z-1e2561a` on both the brain Deployment and the migrate Job (lockstep). No new migrations (schema unchanged at 0005 → goose no-ops); the Job recreates via its `kustomize.toolkit.fluxcd.io/force` annotation. Adds the Scheduled sidebar panel (view/cancel active reminders + agentic tasks) and distinct agentic-notice rendering. Safe regardless of agentic state.

**2. Enable autonomous agentic tasks** — `JANET_AGENTIC_ENABLED=true` (plain env). Registers `schedule_agentic_task` and lets agentic fires run their instruction, gated by the intent judge on the `fast` tier. The judge **fails closed** (denies all if it can't reach its model), so it depends on the gateway `fast` route — which was just validated healthy end-to-end (judge path returned `APPROVE`, tool-call round-trip passed).

Flux applies the migrate Job first (brain `dependsOn` janet-migrate, `wait: true`), then rolls the Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling autonomous agentic task execution increases automation and tool-use surface area; mitigation relies on judge fail-closed behavior and gateway fast-route health.
> 
> **Overview**
> Rolls **janet-brain** to `main-20260624T015822Z-1e2561a` on both the brain Deployment and the migrate Job so releases stay lockstep (migrate runs first via Flux `dependsOn`).
> 
> Turns on **`JANET_AGENTIC_ENABLED=true`** on the brain Deployment, which registers `schedule_agentic_task` and allows scheduled agentic runs to execute their instructions behind the intent judge on **`JANET_JUDGE_MODEL=fast`** (AI gateway). Inline comments note the judge **fails closed** if the fast route is unreachable, so agentic work is denied rather than running ungated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ecb6240e0b4c34eef88c207929157aba5bf3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->