### PR TITLE
feat(janet): deploy Brave Search as an HTTP MCP server

### DIFF
--- a/kubernetes/apps/janet/brain/mcp-config.yaml
+++ b/kubernetes/apps/janet/brain/mcp-config.yaml
@@ -45,6 +45,11 @@ data:
           "approve": ["create", "import"],
           "description": "Google Drive — search/read files, create files & folders, import docs, get shareable links.",
           "keywords": ["drive", "file", "folder", "document"]
+        },
+        "web_search": {
+          "url": "http://brave-search-mcp.janet-mcp.svc.cluster.local:8000/mcp",
+          "description": "Brave Search — web, news, image, video, and local search; summarizer for current events and facts beyond the model's knowledge.",
+          "keywords": ["search", "web", "google", "look up", "news", "latest", "current", "today", "weather", "who is", "what is", "find online"]
         }
       }
     }

--- a/kubernetes/apps/janet/brave-search-mcp/deployment.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/deployment.yaml
@@ -1,0 +1,71 @@
+---
+# Brave Search MCP server (brave/brave-search-mcp-server) — web search as an
+# HTTP MCP capability for the brain ("everything is MCP"). Streamable-HTTP
+# transport on :8000, MCP endpoint at /mcp, health at /ping. The Brave API key
+# is server-side (BRAVE_API_KEY env from the ExternalSecret); the brain talks to
+# this server unauthenticated over the cluster network and never holds the key.
+#
+# Image pulled via mirror.gcr.io (Docker Hub mirror) to dodge docker.io rate
+# limits, pinned by manifest-list digest (multi-arch amd64+arm64).
+# TODO(hardening): egress NetworkPolicy locking this to api.search.brave.com;
+# tighten securityContext to runAsNonRoot once the image's user is confirmed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brave-search-mcp
+  annotations:
+    reloader.stakater.com/auto: "true"
+  labels:
+    app: brave-search-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: brave-search-mcp
+  template:
+    metadata:
+      labels:
+        app: brave-search-mcp
+    spec:
+      containers:
+        - name: server
+          image: mirror.gcr.io/mcp/brave-search@sha256:b8938122495f7857c4cb81b77662f4737367665350700856d61724ce61109fac
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            # Override the v2.x stdio default — serve Streamable HTTP on /mcp.
+            - name: BRAVE_MCP_TRANSPORT
+              value: "http"
+            - name: BRAVE_MCP_HOST
+              value: "0.0.0.0"
+            - name: BRAVE_MCP_PORT
+              value: "8000"
+            - name: BRAVE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: brave-search-mcp
+                  key: BRAVE_API_KEY
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "64Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/kubernetes/apps/janet/brave-search-mcp/externalsecret.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+# Brave Search API key for the MCP server, from GSM
+# (fairy-k8s01-janet-mcp-brave, JSON: {"BRAVE_API_KEY":"..."}). The key lives
+# only on this MCP pod — never on the brain, never in this public repo. The
+# Deployment carries the reloader annotation, so a rotation rolls the pod.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: brave-search-mcp
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    name: brave-search-mcp
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ${CLUSTER_NAME}-janet-mcp-brave

--- a/kubernetes/apps/janet/brave-search-mcp/kustomization.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/kustomization.yaml
@@ -2,10 +2,7 @@
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: janet-mcp
-components:
-  - ../../../../components/flux-post-build-variables
 resources:
-  - ./external-secrets.yaml
-  - ./mcp.yaml
-  - ./brave-search.yaml
+  - ./externalsecret.yaml
+  - ./deployment.yaml
+  - ./service.yaml

--- a/kubernetes/apps/janet/brave-search-mcp/service.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: brave-search-mcp
+spec:
+  selector:
+    app: brave-search-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/kubernetes/clusters/fairy-k8s01/apps/janet-mcp/brave-search.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet-mcp/brave-search.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app brave-search-mcp
+  namespace: &namespace janet-mcp
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets
+      namespace: external-secrets
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/janet/brave-search-mcp
+  interval: 2m
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true

--- a/tofu/janet-mcp.tf
+++ b/tofu/janet-mcp.tf
@@ -24,6 +24,27 @@ resource "google_secret_manager_secret" "janet_mcp_auth" {
   }
 }
 
+# Brave Search MCP server (janet-mcp namespace) — web search capability for the
+# brain. Holds only the Brave Search API key; the brain never sees it. tofu owns
+# the container; push the value once (key from search.brave.com/app/keys):
+#   printf '{"BRAVE_API_KEY":"<api-key>"}' | \
+#     gcloud secrets versions add fairy-k8s01-janet-mcp-brave \
+#       --project=freckle-secrets-db8d4f --data-file=-
+resource "google_secret_manager_secret" "janet_mcp_brave" {
+  secret_id = "fairy-k8s01-janet-mcp-brave"
+  project   = local.project_id
+
+  labels = {
+    cluster   = "fairy-k8s01"
+    namespace = "janet-mcp"
+    consumer  = "brave-search-mcp"
+  }
+
+  replication {
+    auto {}
+  }
+}
+
 # secretAccessor grant for the janet-mcp ns ESO identity — covers
 # fairy-k8s01-janet-mcp-*.
 module "janet_mcp_eso" {


### PR DESCRIPTION
Adds **web search** to the Janet brain as an isolated HTTP MCP capability. Infra-only — no brain code change, no image bump (the brain reads `mcp.json` at startup; Reloader rolls it when the ConfigMap changes).

## What lands
- **`brave-search-mcp` Deployment** (`kubernetes/apps/janet/brave-search-mcp/`) — `brave/brave-search-mcp-server`, Streamable HTTP transport on `:8000`, MCP endpoint `/mcp`, health `/ping`. Its **own Flux Kustomization** (`clusters/fairy-k8s01/apps/janet-mcp/brave-search.yaml`) so a syntax error here can't break `google-workspace-mcp`.
- **Image via `mirror.gcr.io`** (Docker Hub mirror, dodges docker.io rate limits), pinned by multi-arch manifest-list digest `sha256:b893…` (amd64 + arm64).
- **`BRAVE_API_KEY` via GSM** — `fairy-k8s01-janet-mcp-brave` (matches the existing `fairy-k8s01-janet-mcp-*` ESO grant) → `ExternalSecret`. The key lives only on the MCP pod, never on the brain, never in this repo. `tofu/janet-mcp.tf` owns the GSM container.
- **`web_search` entry** in the brain's `mcp-config` ConfigMap → `http://brave-search-mcp.janet-mcp.svc.cluster.local:8000/mcp` (no per-user auth — key is server-side).

## Prereq before it goes Ready
1. `tofu apply` (creates the `fairy-k8s01-janet-mcp-brave` GSM secret).
2. Push the key:
   ```
   printf '{"BRAVE_API_KEY":"<api-key>"}' | \
     gcloud secrets versions add fairy-k8s01-janet-mcp-brave \
       --project=freckle-secrets-db8d4f --data-file=-
   ```
Until then the `brave-search-mcp` KS waits on the ExternalSecret (isolated — doesn't block other apps). The brain's `web_search` capability is lazy-loaded, so the brain rolls cleanly either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new third-party search egress path and secret lifecycle dependency, but follows the existing janet-mcp ESO pattern and keeps the API key off the brain.
> 
> **Overview**
> Adds **web search** to Janet via a new **`brave-search-mcp`** workload in `janet-mcp`, wired into the brain through a **`web_search`** entry in `janet-mcp-config` (ConfigMap-only — no brain image or code change).
> 
> The MCP server runs `brave/brave-search-mcp-server` over **Streamable HTTP** (`/mcp`, health `/ping`), with **`BRAVE_API_KEY`** supplied from GSM through an **ExternalSecret** (`fairy-k8s01-janet-mcp-brave`). **OpenTofu** creates that secret container; operators must apply tofu and add a secret version before the deployment goes Ready. The brain calls the service on the cluster network **without** holding the API key.
> 
> GitOps is split so **`brave-search-mcp`** has its **own Flux Kustomization** under `janet-mcp`, alongside the existing Google Workspace MCP stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 731c2c156b9ccc504974622a488fe4c910621112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->