### PR TITLE
feat(janet): egress-lock brave-search-mcp to api.search.brave.com

### DIFF
--- a/kubernetes/apps/janet/brave-search-mcp/cnp.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/cnp.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/cilium.io/ciliumnetworkpolicy_v2.json
+# Egress lockdown for the Brave Search MCP server. The server only ever talks to
+# api.search.brave.com (web/image/video/news/local/summarizer are all paths
+# under that one host), so pin egress to it on 443. Adding any egress rule flips
+# Cilium to default-deny egress for these pods — no other outbound is possible.
+# DNS resolution (and the DNS-proxy visibility toFQDNs needs) is provided by the
+# cluster-wide intercept-all-dns CCNP, so no explicit DNS rule is required here.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: brave-search-mcp-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app: brave-search-mcp
+  egress:
+    - toFQDNs:
+        - matchName: "api.search.brave.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/janet/brave-search-mcp/deployment.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/deployment.yaml
@@ -6,9 +6,10 @@
 # this server unauthenticated over the cluster network and never holds the key.
 #
 # Image pulled via mirror.gcr.io (Docker Hub mirror) to dodge docker.io rate
-# limits, pinned by manifest-list digest (multi-arch amd64+arm64).
-# TODO(hardening): egress NetworkPolicy locking this to api.search.brave.com;
-# tighten securityContext to runAsNonRoot once the image's user is confirmed.
+# limits, pinned by manifest-list digest (multi-arch amd64+arm64). Egress is
+# locked to api.search.brave.com by cnp.yaml.
+# TODO(hardening): tighten securityContext to runAsNonRoot once the image's
+# user is confirmed.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/apps/janet/brave-search-mcp/kustomization.yaml
+++ b/kubernetes/apps/janet/brave-search-mcp/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./deployment.yaml
   - ./service.yaml
+  - ./cnp.yaml


### PR DESCRIPTION
Stages the egress lockdown flagged as the `TODO(hardening)` when the Brave Search MCP server landed (#1990).

## Surface
Verified against `brave/brave-search-mcp-server` source (`src/BraveAPI/index.ts`): **`api.search.brave.com` is the only outbound host.** Every product — web, image, video, news, local/place, and summarizer — is a path (`/res/v1/...`) under that single host. No non-Brave hosts.

## Policy
`cnp.yaml` — a `CiliumNetworkPolicy` selecting `app: brave-search-mcp`:
- `toFQDNs: api.search.brave.com` on `443/TCP`.
- Adding any egress rule flips Cilium to **default-deny egress** for the pod → nothing else outbound.
- **No explicit DNS rule** — the cluster-wide `intercept-all-dns` CCNP (`enableDefaultDeny: false`) already grants DNS to kube-dns and provides the DNS-proxy visibility `toFQDNs` needs; Cilium unions the allow rules.

Ingress stays open (the brain reaches it in-cluster). The `runAsNonRoot` hardening TODO remains for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow network hardening for a single workload; misconfiguration could block Brave API calls but does not touch auth, secrets, or shared cluster control planes.
> 
> **Overview**
> Implements the egress hardening that was left as a **TODO** on the Brave Search MCP deployment: outbound traffic from `brave-search-mcp` pods is now restricted to **`api.search.brave.com` on TCP 443** via a new `CiliumNetworkPolicy` (`brave-search-mcp-egress`).
> 
> The policy selects pods labeled `app: brave-search-mcp` and uses `toFQDNs` so Cilium applies **default-deny egress** for those endpoints except for that host/port. DNS is not duplicated in this policy; comments note reliance on the cluster-wide intercept-all-dns CCNP for resolution and FQDN visibility.
> 
> `kustomization.yaml` now includes `cnp.yaml`, and `deployment.yaml` comments were updated to point at the policy instead of the open TODO (the `runAsNonRoot` hardening TODO remains).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b738873979baab9e049419925a220abd94f913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->