### PR TITLE
feat(janet): enable web search — bump brain + configure web MCP capability

### DIFF
--- a/kubernetes/apps/janet/brain/deployment.yaml
+++ b/kubernetes/apps/janet/brain/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: janet-brain
-          image: ghcr.io/freckleapps/janet-brain:main-20260624T015822Z-1e2561a
+          image: ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3
           ports:
             - name: http
               containerPort: 8787

--- a/kubernetes/apps/janet/brain/mcp-config.yaml
+++ b/kubernetes/apps/janet/brain/mcp-config.yaml
@@ -46,10 +46,12 @@ data:
           "description": "Google Drive — search/read files, create files & folders, import docs, get shareable links.",
           "keywords": ["drive", "file", "folder", "document"]
         },
-        "web_search": {
+        "web": {
           "url": "http://brave-search-mcp.janet-mcp.svc.cluster.local:8000/mcp",
-          "description": "Brave Search — web, news, image, video, and local search; summarizer for current events and facts beyond the model's knowledge.",
-          "keywords": ["search", "web", "google", "look up", "news", "latest", "current", "today", "weather", "who is", "what is", "find online"]
+          "auth": { "type": "none" },
+          "description": "Web search for current/real-time info or anything past the training cutoff.",
+          "allow": ["web_search", "news_search"],
+          "preload": ["web_search"]
         }
       }
     }

--- a/kubernetes/apps/janet/migrate/migrate-job.yaml
+++ b/kubernetes/apps/janet/migrate/migrate-job.yaml
@@ -37,7 +37,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: ghcr.io/freckleapps/janet-brain:main-20260624T015822Z-1e2561a
+          image: ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3
           args: ["migrate", "up"]
           envFrom:
             # DATABASE_URL (managed janet role on the dedicated cluster).


### PR DESCRIPTION
Turns on web search for the brain now that `brave-search-mcp` is deployed and running in `janet-mcp` (#1990).

## Changes
1. **Brain image** → `ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3` (adds preload-capability support). Migrate Job bumped in lockstep — **no new migrations this release**, so it's a no-op; the `kustomize.toolkit.fluxcd.io/force` annotation recreates it as usual.
2. **`web` capability** in the `janet-mcp-config` ConfigMap, replacing the prior lazy `web_search` entry:
   - `url`: `http://brave-search-mcp.janet-mcp.svc.cluster.local:8000/mcp` — confirmed against the running Service (name `brave-search-mcp`, port 8000, Streamable HTTP at `/mcp`).
   - `preload: [web_search]` → `brave_web_search` is always-on (cached tool prefix, no `load_tools` round-trip).
   - `allow: [web_search, news_search]` → also admits `brave_news_search` (lazy); the other 6 Brave tools stay hidden.
   - `auth: none` (key is server-side on the MCP pod), no `approve` (search is read-only, stays ungated).

## Verified
Live `tools/list` against the running server confirms the tool names — `allow`/`preload` are substring matches, so `web_search`→`brave_web_search` and `news_search`→`brave_news_search` resolve exactly with no over-match.

Reloader auto-rolls the brain on both the image and ConfigMap change — no manual restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and image pin only; search is read-only with no approval gate, and no schema migrations in this release.
> 
> **Overview**
> Enables **web search** for Janet by shipping a newer **janet-brain** image and wiring a **`web` MCP capability** to the in-cluster **Brave Search** server.
> 
> The brain **Deployment** and **migrate Job** both move to `ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3` (preload-capability support in the app). The migrate job stays in lockstep; this release has **no new DB migrations**.
> 
> In **`janet-mcp-config`**, the old lazy **`web_search`** entry becomes **`web`**: same Brave MCP URL, **`auth: none`**, **`allow`** limited to web and news search tools, and **`preload: [web_search]`** so general web search is always available without a `load_tools` hop. Reloader is expected to roll the brain on image + ConfigMap changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018ac760d4cccde0ecc43f876d02f701526523c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->