### PR TITLE
feat(iua): automate janet-brain image bumps

### DIFF
--- a/kubernetes/apps/flux/image-automation/imagepolicy-janet-brain.yaml
+++ b/kubernetes/apps/flux/image-automation/imagepolicy-janet-brain.yaml
@@ -1,0 +1,24 @@
+---
+# Selects the latest janet-brain image tag matching `main-<ts>-<sha>`. Extracts
+# the timestamp and picks the highest (= most recent build). The single
+# ImageUpdateAutomation rewrites both marked `image:` fields that reference this
+# policy — the brain Deployment and the migrate Job — so they always move in
+# lockstep (marker: # {"$imagepolicy": "flux-system:janet-brain"}).
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: janet-brain
+spec:
+  imageRepositoryRef:
+    name: janet-brain
+    # Same namespace (flux-system) as this policy + the automation — no
+    # cross-namespace accessFrom needed.
+    namespace: flux-system
+  filterTags:
+    pattern: '^main-(?P<ts>[0-9]{8}T[0-9]{6}Z)-[a-f0-9]+$'
+    extract: '$ts'
+  policy:
+    # Fixed-width ISO 8601 compact UTC (YYYYMMDDTHHMMSSZ) is lex-sortable —
+    # alphabetical ascending = chronological. Latest = highest.
+    alphabetical:
+      order: asc

--- a/kubernetes/apps/flux/image-automation/imagerepository-janet-brain.yaml
+++ b/kubernetes/apps/flux/image-automation/imagerepository-janet-brain.yaml
@@ -1,0 +1,20 @@
+---
+# Scans the private janet-brain container image so the ImageUpdateAutomation can
+# track new builds. Lives in flux-system on atlantis (the only cluster running
+# the committer) alongside the ImagePolicy + automation, even though janet-brain
+# runs on fairy — the marker rewrite is a git operation, so the scanner just
+# needs to live wherever the automation reads its ImagePolicies.
+#
+# Reuses harvest-ghcr-login: the same shared GHCR read PAT (1Password
+# hedgehog-ghcr) reads both freckleapps org packages and the personal nicolerenee
+# packages, so one docker-config secret covers all flux-system scanners.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/image.toolkit.fluxcd.io/imagerepository_v1.json
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: janet-brain
+spec:
+  image: ghcr.io/freckleapps/janet-brain
+  interval: 5m
+  secretRef:
+    name: harvest-ghcr-login

--- a/kubernetes/apps/flux/image-automation/kustomization.yaml
+++ b/kubernetes/apps/flux/image-automation/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ./ghcr-login.externalsecret.yaml
   - ./imagerepository-harvest.yaml
+  - ./imagerepository-janet-brain.yaml
   - ./imagepolicy-hedgehog.yaml
   - ./imagepolicy-harvest.yaml
+  - ./imagepolicy-janet-brain.yaml
   - ./imageupdateautomation.yaml

--- a/kubernetes/apps/janet/brain/deployment.yaml
+++ b/kubernetes/apps/janet/brain/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: janet-brain
-          image: ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3
+          image: ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3 # {"$imagepolicy": "flux-system:janet-brain"}
           ports:
             - name: http
               containerPort: 8787

--- a/kubernetes/apps/janet/migrate/migrate-job.yaml
+++ b/kubernetes/apps/janet/migrate/migrate-job.yaml
@@ -37,7 +37,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: migrate
-          image: ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3
+          image: ghcr.io/freckleapps/janet-brain:main-20260624T030935Z-40db8a3 # {"$imagepolicy": "flux-system:janet-brain"}
           args: ["migrate", "up"]
           envFrom:
             # DATABASE_URL (managed janet role on the dedicated cluster).


### PR DESCRIPTION
Sets up Flux image automation for `janet-brain` so the manual lockstep tag bumps go away.

## What
- **`imagerepository-janet-brain.yaml`** — scans `ghcr.io/freckleapps/janet-brain` every 5m. Reuses **`harvest-ghcr-login`** (the shared GHCR read PAT in flux-system, documented as reading freckleapps org packages) — no new secret.
- **`imagepolicy-janet-brain.yaml`** — same `^main-<ts>-<sha>$` filter + `alphabetical(asc)` policy as harvest (timestamp is lex-sortable → latest = highest).
- **Markers** (`# {"$imagepolicy": "flux-system:janet-brain"}`) on **both** the brain Deployment and the migrate Job image fields → they always move in lockstep, picked up by the existing repo-wide `ImageUpdateAutomation` (pushes directly to main).

## Notes
- All in flux-system on atlantis (same ns as the automation) → no cross-ns `accessFrom`. The `nicolerenee-flux` committer already pushes to main (harvest works), so no GitHub Ruleset change.
- The current tag `main-20260624T030935Z-40db8a3` is already the latest build, so **merging is a no-op** — the first real rewrite happens on the next janet-brain build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitOps-only Flux resources and image markers; no runtime app logic changes, and the current tag already matches latest until the next build.
> 
> **Overview**
> Adds Flux **ImageRepository** and **ImagePolicy** for `ghcr.io/freckleapps/janet-brain`, wired into the existing flux-system image-automation kustomization. Tag selection mirrors harvest: `main-<timestamp>-<sha>` with lexicographic “latest” on the timestamp.
> 
> Annotates the **janet-brain** Deployment and **janet-migrate** Job image fields with `# {"$imagepolicy": "flux-system:janet-brain"}` so the repo-wide **ImageUpdateAutomation** can bump both tags together. GHCR scanning reuses **`harvest-ghcr-login`**; no new credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a4ceebe5ad2222de977fe7c3d27ab875b4e2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->