### PR TITLE
feat(janet): models.json registry + expose Qwen by real name + SA-token auth

### DIFF
--- a/kubernetes/apps/janet/brain/deployment.yaml
+++ b/kubernetes/apps/janet/brain/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app.kubernetes.io/name: janet-brain
     spec:
+      serviceAccountName: janet-brain
       imagePullSecrets:
         - name: ghcr-pull
       securityContext:
@@ -42,25 +43,17 @@ spec:
           env:
             - name: PORT
               value: "8787"
-            # Semantic names — resolved by the AI gateway to a concrete backend
-            # (local qwen today). Brain default + judge lane.
-            - name: JANET_MODEL
-              value: chat
-            - name: JANET_JUDGE_MODEL
-              value: fast
+            # Model registry: endpoint, model roles (default + judge), auth, and
+            # capabilities all live in the mounted models.json now — replaces the
+            # old JANET_MODEL / JANET_JUDGE_MODEL env vars and ANTHROPIC_BASE_URL.
+            - name: JANET_MODELS_CONFIG
+              value: /etc/janet-models/models.json
             # Registers schedule_agentic_task and lets agentic fires run their
-            # instruction, gated by the intent judge (JANET_JUDGE_MODEL=fast via
-            # the gateway). Judge fails closed — denies all if it can't reach its
-            # model — so the gateway fast route must be healthy.
+            # instruction, gated by the intent judge (judge_models in models.json).
+            # Judge fails closed — denies all if it can't reach its model — so the
+            # gateway route for the judge model must be healthy.
             - name: JANET_AGENTIC_ENABLED
               value: "true"
-            # Keyless: the AI gateway holds the real Anthropic key. The
-            # placeholder only satisfies the SDK's credential precondition;
-            # the gateway overrides whatever the client sends.
-            - name: ANTHROPIC_BASE_URL
-              value: http://ai-gateway.inference.svc.cluster.local/anthropic
-            - name: ANTHROPIC_API_KEY
-              value: placeholder-gateway-injects-real-key
             - name: OIDC_ISSUER
               value: https://freckle.id
             - name: OIDC_REDIRECT_URL
@@ -125,9 +118,28 @@ spec:
             - name: mcp-config
               mountPath: /etc/janet
               readOnly: true
+            - name: models-config
+              mountPath: /etc/janet-models
+              readOnly: true
+            - name: gateway-token
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
       volumes:
         - name: tmp
           emptyDir: {}
         - name: mcp-config
           configMap:
             name: janet-mcp-config
+        - name: models-config
+          configMap:
+            name: janet-models-config
+        # Rotating projected SA token the brain attaches per request (k8s_sa auth
+        # in models.json). Audience must match the future gateway JWT policy; until
+        # that lands the token is sent and ignored. File: /var/run/secrets/tokens/gateway-token.
+        - name: gateway-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: ai-gateway.inference
+                  expirationSeconds: 3600
+                  path: gateway-token

--- a/kubernetes/apps/janet/brain/kustomization.yaml
+++ b/kubernetes/apps/janet/brain/kustomization.yaml
@@ -3,8 +3,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./serviceaccount.yaml
   - ./externalsecret.yaml
   - ./mcp-config.yaml
+  - ./models-config.yaml
   - ./deployment.yaml
   - ./service.yaml
   - ./httproute.yaml

--- a/kubernetes/apps/janet/brain/models-config.yaml
+++ b/kubernetes/apps/janet/brain/models-config.yaml
@@ -15,7 +15,7 @@
 # credential, never a stale key.
 #
 # properties.secure must stay honest with what the endpoint enforces: the qwen
-# backend is egress-locked on-prem DGX (see apps/inference/qwen36-35b-a3b/cnp.yaml),
+# backend is egress-locked on-prem DGX (see kubernetes/apps/inference/qwen36-35b-a3b/cnp.yaml),
 # so secure+local are true.
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/apps/janet/brain/models-config.yaml
+++ b/kubernetes/apps/janet/brain/models-config.yaml
@@ -1,0 +1,40 @@
+---
+# The brain's model registry (JANET_MODELS_CONFIG points here). Replaces the old
+# JANET_MODEL / JANET_JUDGE_MODEL env vars and the global ANTHROPIC_BASE_URL: the
+# endpoint, model roles, auth, and capabilities now all live in this ConfigMap.
+# Editing a model is a ConfigMap change — Reloader rolls the brain, no rebuild.
+#
+# `id` is our canonical name (what threads/users reference). `model` is the real
+# name the AI gateway routes — we call Qwen directly (model=Qwen3.6-35B-A3B-FP8,
+# matched by the leading rule in ai-routes/route.yaml), not via a tier alias.
+#
+# Auth `k8s_sa`: the brain sends its projected ServiceAccount token (mounted at
+# /var/run/secrets/tokens/gateway-token, audience ai-gateway.inference). The
+# gateway doesn't validate it yet (JWT SecurityPolicy is a later step), so it's
+# sent and ignored — harmless. If the token file is absent the brain sends no
+# credential, never a stale key.
+#
+# properties.secure must stay honest with what the endpoint enforces: the qwen
+# backend is egress-locked on-prem DGX (see apps/inference/qwen36-35b-a3b/cnp.yaml),
+# so secure+local are true.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: janet-models-config
+data:
+  models.json: |
+    {
+      "default_endpoint": "http://ai-gateway.inference.svc.cluster.local/v1/",
+      "default_model": "qwen3.6-35b-a3b",
+      "judge_models": ["qwen3.6-35b-a3b"],
+      "models": [
+        {
+          "id": "qwen3.6-35b-a3b",
+          "label": "Qwen 3.6 (35B-A3B)",
+          "model": "Qwen3.6-35B-A3B-FP8",
+          "auth": { "type": "k8s_sa", "audience": "ai-gateway.inference" },
+          "capabilities": ["thinking"],
+          "properties": { "secure": true, "local": true }
+        }
+      ]
+    }

--- a/kubernetes/apps/janet/brain/serviceaccount.yaml
+++ b/kubernetes/apps/janet/brain/serviceaccount.yaml
@@ -1,0 +1,10 @@
+---
+# Dedicated identity for the brain. The projected gateway-token volume mints a
+# token with this SA's subject (system:serviceaccount:janet:janet-brain) so the
+# future gateway JWT SecurityPolicy can attribute requests to it. No RBAC is
+# bound — the SA exists purely as a token identity, not for Kubernetes API access.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: janet-brain
+automountServiceAccountToken: false

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
@@ -51,7 +51,21 @@ spec:
   # One rule per semantic name. All six resolve to the same backend today; when a
   # dedicated coder/27B backend lands, only that rule's backendRef re-points —
   # callers never change.
+  #
+  # The leading rule exposes the model by its real served name. The brain's
+  # models.json registry sends model=Qwen3.6-35B-A3B-FP8 directly (no tier
+  # indirection), so this is the rule Janet actually hits today; it also makes the
+  # name appear in the gateway's GET /v1/models. The tier rules below stay until
+  # nothing references them, then get removed.
   rules:
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: Qwen3.6-35B-A3B-FP8
+      backendRefs:
+        - name: local-qwen36-35b-a3b
+          modelNameOverride: qwen3.6-35b-a3b
     - matches:
         - headers:
             - type: Exact


### PR DESCRIPTION
Lands the brain's `models.json` model registry, exposes Qwen by its real served name at the gateway, and wires SA-token auth — ready for the next janet-brain image (PR #11) that makes `JANET_MODELS_CONFIG` required.

## Changes
- **Gateway — real name route** (`ai-routes/route.yaml`): leading `AIGatewayRoute` rule routes `Qwen3.6-35B-A3B-FP8` → `local-qwen36-35b-a3b` (`modelNameOverride: qwen3.6-35b-a3b`, the alias vLLM serves). Makes the name appear in `GET /v1/models` and is the rule Janet actually hits now that it sends the real name. Tier rules (chat/fast/…) stay until nothing references them.
- **`models.json` registry** (`brain/models-config.yaml`, new `janet-models-config` ConfigMap): `default_endpoint` → gateway OpenAI `/v1/`, `default_model`/`judge_models` = `qwen3.6-35b-a3b`, one model mapping `id` → `model: Qwen3.6-35B-A3B-FP8`, `auth: k8s_sa`, `capabilities: [thinking]`, `properties: {secure, local}`.
- **Brain Deployment**: drop `JANET_MODEL`/`JANET_JUDGE_MODEL`/`ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY`; add `JANET_MODELS_CONFIG=/etc/janet-models/models.json`; mount the ConfigMap at `/etc/janet-models` (separate dir — `/etc/janet` is the mcp-config mount).
- **SA-token auth** (`brain/serviceaccount.yaml`): dedicated `janet-brain` SA (no RBAC, `automountServiceAccountToken: false`) so the projected token's subject is `system:serviceaccount:janet:janet-brain`. Projected `gateway-token` volume (audience `ai-gateway.inference`, 1h) at `/var/run/secrets/tokens/gateway-token`.

## Notes
- The gateway JWT SecurityPolicy (enforcement) is deferred per the handoff — the token is sent-and-ignored until then, harmless.
- Handoff's example token `path: token` contradicted its own prose read-path; used `path: gateway-token` to match where the brain reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Janet’s inference wiring (endpoint, model IDs, and auth path) and gateway routing; misconfiguration could break chat/agentic judge until the companion brain image that requires `JANET_MODELS_CONFIG` is deployed.
> 
> **Overview**
> Janet-brain **model configuration moves from env vars into a mounted `models.json` registry**, with gateway routing updated so inference uses the real Qwen served name instead of tier aliases.
> 
> The deployment drops `JANET_MODEL`, `JANET_JUDGE_MODEL`, `ANTHROPIC_BASE_URL`, and the placeholder `ANTHROPIC_API_KEY`, and sets **`JANET_MODELS_CONFIG`** to a new **`janet-models-config`** ConfigMap (default/judge models, OpenAI `/v1/` endpoint on the in-cluster gateway, `k8s_sa` auth, capabilities/properties). A dedicated **`janet-brain` ServiceAccount** and a **projected gateway token** volume supply credentials for future gateway JWT enforcement (sent but not validated yet).
> 
> The **AI gateway `local-models` route** gains a **leading rule** for `x-ai-eg-model: Qwen3.6-35B-A3B-FP8` → the local Qwen backend, matching what the registry sends and surfacing the name on `GET /v1/models`; legacy tier rules (`chat`, `fast`, etc.) remain for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c65ff6b14359aef1f2c7e9faeca51a174b2cfec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->