### PR TITLE
refactor(inference): drop tier-name routes from local-models AIGatewayRoute

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
@@ -48,69 +48,18 @@ spec:
     - name: ai
       kind: Gateway
       group: gateway.networking.k8s.io
-  # One rule per semantic name. All six resolve to the same backend today; when a
-  # dedicated coder/27B backend lands, only that rule's backendRef re-points —
-  # callers never change.
-  #
-  # The leading rule exposes the model by its real served name. The brain's
-  # models.json registry sends model=Qwen3.6-35B-A3B-FP8 directly (no tier
-  # indirection), so this is the rule Janet actually hits today; it also makes the
-  # name appear in the gateway's GET /v1/models. The tier rules below stay until
-  # nothing references them, then get removed.
+  # The brain's models.json registry sends model=Qwen3.6-35B-A3B-FP8 directly, so
+  # this single rule (matching the real served name) is what Janet hits and what
+  # surfaces the model in the gateway's GET /v1/models. The old tier names
+  # (chat/fast/planning/code/secure-local/secure-ephemeral) were removed once
+  # nothing referenced them. When a dedicated coder/27B backend lands, add a rule
+  # matching its served name pointing at that backend.
   rules:
     - matches:
         - headers:
             - type: Exact
               name: x-ai-eg-model
               value: Qwen3.6-35B-A3B-FP8
-      backendRefs:
-        - name: local-qwen36-35b-a3b
-          modelNameOverride: qwen3.6-35b-a3b
-    - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: chat
-      backendRefs:
-        - name: local-qwen36-35b-a3b
-          modelNameOverride: qwen3.6-35b-a3b
-    - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: fast
-      backendRefs:
-        - name: local-qwen36-35b-a3b
-          modelNameOverride: qwen3.6-35b-a3b
-    - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: planning
-      backendRefs:
-        - name: local-qwen36-35b-a3b
-          modelNameOverride: qwen3.6-35b-a3b
-    - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: code
-      backendRefs:
-        - name: local-qwen36-35b-a3b
-          modelNameOverride: qwen3.6-35b-a3b
-    - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: secure-local
-      backendRefs:
-        - name: local-qwen36-35b-a3b
-          modelNameOverride: qwen3.6-35b-a3b
-    - matches:
-        - headers:
-            - type: Exact
-              name: x-ai-eg-model
-              value: secure-ephemeral
       backendRefs:
         - name: local-qwen36-35b-a3b
           modelNameOverride: qwen3.6-35b-a3b


### PR DESCRIPTION
Now that Janet's brain sends `model=Qwen3.6-35B-A3B-FP8` directly via its `models.json` registry (#1996), the tier-name rules on the `local-models` `AIGatewayRoute` are unused. This removes them, leaving the single real-name rule.

## Change
- `ai-routes/route.yaml`: drop the `chat` / `fast` / `planning` / `code` / `secure-local` / `secure-ephemeral` rules. Keep the `Qwen3.6-35B-A3B-FP8` → `local-qwen36-35b-a3b` (`modelNameOverride: qwen3.6-35b-a3b`) rule.

## Effect
- `GET /v1/models` will list `Qwen3.6-35B-A3B-FP8` (plus the untouched `claude-*` Anthropic names); the six tier names drop off.
- A future coder/27B backend adds its own served-name rule when it lands.

Verified nothing references the tiers: brain `models.json` targets the real name only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gateway routing config cleanup only; primary traffic already uses the real model name. Residual risk is any forgotten client still sending a tier alias would no longer match.
> 
> **Overview**
> Removes six **unused** `local-models` `AIGatewayRoute` rules that matched tier aliases (`chat`, `fast`, `planning`, `code`, `secure-local`, `secure-ephemeral`) and all forwarded to the same `local-qwen36-35b-a3b` backend.
> 
> Routing now relies on the single rule matching **`Qwen3.6-35B-A3B-FP8`**, which aligns with Janet’s brain `models.json` sending that served name directly. **`GET /v1/models`** will stop advertising the tier names and only expose the real local model id (Anthropic routes unchanged). Comments are updated to document the removal and how to add a future coder/27B rule by served name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ae654eca0303ecc8ab4d243a26fe41f34de1a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->