### PR TITLE
feat(hedgehog): deploy shared jina-reader to hedgehog namespace

### DIFF
--- a/kubernetes/apps/janet/jina-reader/reader-cnp.yaml
+++ b/kubernetes/apps/janet/jina-reader/reader-cnp.yaml
@@ -9,12 +9,18 @@
 #   - link-local / cloud-metadata (169.254.0.0/16)
 #   - IPv6 ULA + link-local (fc00::/7, fe80::/10)
 #
-# The 10/8 and fc00::/7 denies would otherwise swallow the cluster's own
-# service/pod CIDRs — and CoreDNS lives in the service CIDR — so those ranges
-# are `except`ed to keep in-cluster DNS working. The except does NOT grant the
-# reader access to cluster pods/services: only `toEntities: world` allows
-# anything, and that never covers cluster entities. Cluster-internal pods/
-# services/nodes are blocked by default-deny egress once any egress rule exists.
+# No `except` for the cluster's own service/pod CIDRs is needed even though they
+# sit inside 10/8 and fc00::/7: Cilium CIDR rules (allow AND deny) never govern
+# traffic where both ends are Cilium-managed — in-cluster peers are matched by
+# their pod identity, not by IP. So this deny simply doesn't apply to
+# reader→CoreDNS (both Cilium-managed); DNS keeps working (and is separately
+# allowed by the cluster-wide intercept-all-dns CCNP). Because there are no
+# hardcoded cluster CIDRs, this policy is cluster-agnostic and shared verbatim by
+# every jina-reader Flux Kustomization (janet-mcp on fairy, hedgehog on atlantis).
+# The reader still cannot reach other in-cluster pods/services: nothing here
+# allows the `cluster` entity, so default-deny egress blocks them. Node/host IPs
+# in RFC1918 ARE covered by the deny (node networking isn't Cilium-managed) —
+# which is intended: the reader must not reach mgmt/node addresses.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -43,15 +49,9 @@ spec:
   egressDeny:
     - toCIDRSet:
         - cidr: 10.0.0.0/8
-          except:
-            - 10.229.0.0/16   # cluster service CIDR (CoreDNS)
-            - 10.230.0.0/16   # cluster pod CIDR
         - cidr: 172.16.0.0/12
         - cidr: 192.168.0.0/16
         - cidr: 100.64.0.0/10
         - cidr: 169.254.0.0/16
         - cidr: fc00::/7
-          except:
-            - fd2b:ec92:e230:1::/112   # cluster service CIDR (CoreDNS)
-            - fd2b:ec92:e232::/48      # cluster pod CIDR
         - cidr: fe80::/10

--- a/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/jina-reader.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/jina-reader.yaml
@@ -1,0 +1,27 @@
+---
+# Self-hosted Jina Reader for hedgehog — URL→Markdown fetcher reachable in-cluster
+# at http://jina-reader.hedgehog.svc:8081/<url>. Egress-locked to the public
+# internet only (see reader-cnp.yaml). Reuses the shared, cluster-agnostic app
+# manifests under kubernetes/apps/janet/jina-reader (same dir the fairy janet-mcp
+# instance points at) — targetNamespace lands them in hedgehog.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app jina-reader
+  namespace: &namespace hedgehog
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/janet/jina-reader
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./platform.yaml
   - ./db.yaml
   - ./queue.yaml
+  - ./jina-reader.yaml
   - ./hedgehog.yaml


### PR DESCRIPTION
## What

Deploys a self-hosted Jina Reader (URL→Markdown fetcher) into the `hedgehog` namespace on **atlantis-k8s01** for hedgehog to consume at `http://jina-reader.hedgehog.svc:8081/<url>`.

Rather than duplicating manifests, this reuses the **existing shared app dir** `kubernetes/apps/janet/jina-reader` — the same Deployment/Service/CNP the fairy `janet-mcp` instance already runs. A new Flux Kustomization pointer under `clusters/atlantis-k8s01/apps/hedgehog/` targets that dir with `targetNamespace: hedgehog`.

## CNP change (why it's now shared, not duplicated)

The reader's egress CNP previously carried `except:` carve-outs for fairy's service/pod CIDRs, ostensibly to keep CoreDNS reachable. Those were **redundant**: [Cilium CIDR rules never govern traffic where both ends are Cilium-managed](https://docs.cilium.io/en/stable/security/policy/layer3/), so the `10.0.0.0/8` / `fc00::/7` `egressDeny` never applied to reader→CoreDNS. Dropping the excepts removes the only cluster-specific values, making the CNP **cluster-agnostic** so both instances share it verbatim.

SSRF containment is unchanged: reader still reaches `world` on 80/443 only, still cannot reach other in-cluster pods/services (no `toEntities: cluster` allow — that was deliberately avoided), and node/host RFC1918 IPs remain denied.

## Follow-up (not in this PR)

`kubernetes/apps/janet/*` will be reorganized under an `inference/{mcp,janet,models}` category later; deferred until this merges.

## Validation

- `kubectl kustomize` builds clean for the shared app dir and both cluster-apps dirs.
- Both fairy `janet-mcp` and atlantis `hedgehog` pointers render `path: ./kubernetes/apps/janet/jina-reader`.
- Built CNP contains no cluster CIDRs / no `except`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF egress lockdown for jina-reader; behavior is intended to be equivalent but Cilium policy semantics warrant careful review on both clusters.
> 
> **Overview**
> Adds a **Flux Kustomization** on **atlantis-k8s01** so **hedgehog** runs the same shared `kubernetes/apps/janet/jina-reader` manifests as fairy’s **janet-mcp** instance, exposing in-cluster `http://jina-reader.hedgehog.svc:8081/<url>`.
> 
> Updates **`reader-cnp.yaml`** by removing fairy-specific **`except`** carve-outs on the `10.0.0.0/8` and `fc00::/7` **egressDeny** rules and expanding comments to explain that Cilium CIDR rules don’t apply to Cilium-managed pod-to-pod traffic (so reader→CoreDNS is unaffected). The policy is now **cluster-agnostic** with no hardcoded service/pod CIDRs; SSRF posture is unchanged—**world** on 80/443 only, no in-cluster **cluster** allow, private ranges still denied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2721dda4012cb4788d5ad54506495b6475378f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->