### PR TITLE
feat(janet): explicit Qwen reasoning spec in models-config

### DIFF
--- a/kubernetes/apps/inference/janet/brain/models-config.yaml
+++ b/kubernetes/apps/inference/janet/brain/models-config.yaml
@@ -34,6 +34,7 @@ data:
           "model": "Qwen3.6-35B-A3B-FP8",
           "auth": { "type": "k8s_sa", "audience": "ai-gateway.inference" },
           "capabilities": ["thinking"],
+          "reasoning": { "control": "toggle", "levels": ["off", "on"], "default": "off", "mechanism": "qwen_enable_thinking" },
           "properties": { "secure": true, "local": true }
         }
       ]


### PR DESCRIPTION
Adds an explicit `reasoning` spec to the Qwen entry in the brain's model registry, for janet-brain's per-model reasoning capability (PR #43).

- `reasoning: {control: toggle, levels: [off,on], default: off, mechanism: qwen_enable_thinking}` — validated against #43's fail-closed mechanism↔control matrix (toggle + qwen_enable_thinking, default in levels).
- **default `off`** matches today's behavior (interactive threads default thinking off; the scheduled briefing flips it on explicitly). Change to `"on"` if you'd prefer Qwen to think by default.
- Kept `capabilities:["thinking"]` — the pre-#43 brain and native clients still read it; the #43 brain prefers `reasoning` when present, else synthesizes the same toggle from the capability. So this is **additive and safe** regardless of rollout order (unknown field is ignored by the old brain).
- ConfigMap edit → Reloader rolls the brain (no rebuild). `models.json` validated to parse + match the spec matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to a model registry; default reasoning stays off and unknown fields are safe for pre-#43 brain versions.
> 
> **Overview**
> Adds an explicit **`reasoning`** block to the Qwen model entry in the brain **`models.json`** ConfigMap so janet-brain (#43) can drive per-model reasoning without inferring it only from **`capabilities`**.
> 
> The new spec is a **toggle** with levels **`off` / `on`**, **`default: off`** (same as today for interactive threads; briefing can still turn thinking on), and mechanism **`qwen_enable_thinking`**. **`capabilities: ["thinking"]`** is unchanged for older brain builds and native clients; the new field is additive and ignored if the brain does not understand it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ac6a6b823239e3d9d3516a0788eca2a3d347ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->