### PR TITLE
feat(janet): wire GitHub App OAuth for background coding runs (brain)

### DIFF
--- a/kubernetes/apps/inference/janet/brain/deployment.yaml
+++ b/kubernetes/apps/inference/janet/brain/deployment.yaml
@@ -67,6 +67,15 @@ spec:
             # must match the App's callback exactly.
             - name: GITHUB_REDIRECT_URL
               value: https://janet.fairy.freckle.services/auth/github/callback
+            # Background coding runs. JANET_CODING_ENABLED gates the coding chat
+            # tools + /coding-runs API. Inert until the M2 image ships (the flag
+            # is unread by the current binary); once live, runs just park in
+            # `queued` until the janet-controller exists (§2). Placed ahead of
+            # time so the feature surfaces the moment M2's image auto-deploys.
+            - name: JANET_CODING_ENABLED
+              value: "true"
+            - name: JANET_CODING_MAX_ACTIVE_PER_USER
+              value: "10"
             # MCP servers are declared in the mounted ConfigMap, not hardcoded.
             - name: JANET_MCP_CONFIG
               value: /etc/janet/mcp.json

--- a/kubernetes/apps/inference/janet/brain/deployment.yaml
+++ b/kubernetes/apps/inference/janet/brain/deployment.yaml
@@ -48,12 +48,6 @@ spec:
             # old JANET_MODEL / JANET_JUDGE_MODEL env vars and ANTHROPIC_BASE_URL.
             - name: JANET_MODELS_CONFIG
               value: /etc/janet-models/models.json
-            # Registers schedule_agentic_task and lets agentic fires run their
-            # instruction, gated by the intent judge (judge_models in models.json).
-            # Judge fails closed — denies all if it can't reach its model — so the
-            # gateway route for the judge model must be healthy.
-            - name: JANET_AGENTIC_ENABLED
-              value: "true"
             - name: OIDC_ISSUER
               value: https://freckle.id
             - name: OIDC_REDIRECT_URL
@@ -67,6 +61,12 @@ spec:
             # Deep-link the native Mac app back after Google connect completes.
             - name: JANET_GOOGLE_NATIVE_RETURN
               value: janet://google-connected
+            # GitHub App OAuth (per-user token vault for background coding runs).
+            # GITHUB_CLIENT_ID + GITHUB_CLIENT_SECRET come from the janet-github
+            # secret (envFrom); the vault reuses JANET_TOKEN_ENC_KEY. This URL
+            # must match the App's callback exactly.
+            - name: GITHUB_REDIRECT_URL
+              value: https://janet.fairy.freckle.services/auth/github/callback
             # MCP servers are declared in the mounted ConfigMap, not hardcoded.
             - name: JANET_MCP_CONFIG
               value: /etc/janet/mcp.json
@@ -79,6 +79,9 @@ spec:
             # GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET (keys = env-var names).
             - secretRef:
                 name: janet-google
+            # GITHUB_CLIENT_ID + GITHUB_CLIENT_SECRET (keys = env-var names).
+            - secretRef:
+                name: janet-github
             # OIDC_CLIENT_ID.
             - secretRef:
                 name: janet-oidc

--- a/kubernetes/apps/inference/janet/brain/externalsecret.yaml
+++ b/kubernetes/apps/inference/janet/brain/externalsecret.yaml
@@ -18,6 +18,26 @@ spec:
         key: ${CLUSTER_NAME}-janet-google
 ---
 # yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+# GitHub App OAuth client (id + secret) from GSM, for the per-user token vault
+# behind background coding runs. JSON keys = env-var names, consumed via
+# envFrom. Externally issued (GitHub App), pushed to GSM by hand — same shape
+# as janet-google. The vault reuses JANET_TOKEN_ENC_KEY (no separate key).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: janet-github
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    name: janet-github
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ${CLUSTER_NAME}-janet-github
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
 # Freckle ID (pocket-id) client id from GSM — stored by tofu when it mints the
 # client. Raw value mapped to the OIDC_CLIENT_ID env var.
 apiVersion: external-secrets.io/v1

--- a/tofu/janet.tf
+++ b/tofu/janet.tf
@@ -30,6 +30,31 @@ resource "google_secret_manager_secret" "janet_google" {
   }
 }
 
+#   fairy-k8s01-janet-github — the "janet" GitHub App's OAuth client id +
+#     secret, for the per-user token vault behind background coding runs.
+#     Externally issued (GitHub App registration), so tofu owns only the
+#     container; the value is pushed by hand, never in state — same as
+#     janet-google:
+#       printf '{"GITHUB_CLIENT_ID":"<id>","GITHUB_CLIENT_SECRET":"<secret>"}' | \
+#         gcloud secrets versions add fairy-k8s01-janet-github \
+#           --project=freckle-secrets-db8d4f --data-file=-
+#     The vault is encrypted with the existing JANET_TOKEN_ENC_KEY (reused, not
+#     a new key). Covered by the janet eso-namespace prefix grant.
+resource "google_secret_manager_secret" "janet_github" {
+  secret_id = "fairy-k8s01-janet-github"
+  project   = local.project_id
+
+  labels = {
+    cluster   = "fairy-k8s01"
+    namespace = "janet"
+    consumer  = "janet-brain"
+  }
+
+  replication {
+    auto {}
+  }
+}
+
 # OIDC client id, stored by tofu since tofu mints it. Final secret_id is
 # `fairy-k8s01-janet-oidc`, covered by the janet eso-namespace prefix grant.
 module "janet_oidc" {


### PR DESCRIPTION
Lands the **deployable-now slice** of the background-coding-agent infra plan (brain only), plus the coding-run feature flags pre-placed ahead of M2. The brain already ships the "Connect GitHub" OAuth flow + per-user encrypted token vault — that's `janet-brain` **PR #52** (merged 2026-07-04, present in the running image `main-20260704T222110Z`) — so it just needs its GitHub App credentials, callback URL, and feature flags.

## Changes
- **`tofu/janet.tf`** — GSM container `fairy-k8s01-janet-github` (client id + secret). Externally issued via the GitHub App registration, so tofu owns only the container and the value is hand-pushed — identical pattern to `janet-google`. Already covered by the janet ESO namespace prefix grant.
- **`externalsecret.yaml`** — `janet-github` ExternalSecret; `dataFrom extract` with JSON keys = env-var names, consumed via `envFrom`.
- **`deployment.yaml`**:
  - `envFrom: janet-github` + literal `GITHUB_REDIRECT_URL=https://janet.fairy.freckle.services/auth/github/callback` (must match the App callback exactly). The vault **reuses the existing `JANET_TOKEN_ENC_KEY`** — no new key.
  - `JANET_CODING_ENABLED=true` + `JANET_CODING_MAX_ACTIVE_PER_USER=10` — the coding-run feature flags, pre-placed (see below).
  - **Removes the dead `JANET_AGENTIC_ENABLED`** env (dropped in-code by PR #49; agentic is always on).

## Coding flags are pre-placed, inert until M2
`JANET_CODING_ENABLED` gates the `/coding-runs` API + coding chat tools from **M2 (PR #53, still open)**. The current binary's `config.go` doesn't read these vars, so **they do nothing until M2's image auto-deploys** via image automation. At that point the feature surfaces immediately and runs park in `queued` until the `janet-controller` exists (§2 of the handoff) — no separate flip-the-switch PR. This is the handoff-sanctioned "enable now, runs queue" path.

## Status: prerequisites cleared ✅
- GitHub App registered; credentials pushed to GSM `fairy-k8s01-janet-github` (version 1 live).
- `tofu apply` run — GSM container exists.

On merge, Flux reconciles the `janet-github` ExternalSecret → ESO pulls the value → the brain pod rolls with the GitHub env, and "Connect GitHub" goes live.

## Validation
- `kubectl kustomize kubernetes/apps/inference/janet/brain/` builds clean.
- Env-var names (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` / `GITHUB_REDIRECT_URL`) verified against merged `internal/config/config.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)