### PR TITLE
fix(janet): allow janet-brain egress to github.com for GitHub OAuth

### DIFF
--- a/kubernetes/apps/inference/janet/brain/cnp-egress.yaml
+++ b/kubernetes/apps/inference/janet/brain/cnp-egress.yaml
@@ -81,3 +81,19 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # GitHub App OAuth for background coding runs (per-user token vault). Both
+    # entries are required and non-overlapping:
+    #   - matchName github.com : the OAuth token exchange/refresh endpoint
+    #     (github.com/login/oauth/access_token) is on the BARE apex. A wildcard
+    #     pattern never matches the apex, so it must be listed explicitly.
+    #   - matchPattern **.github.com : api.github.com (App/user API). `**` (not a
+    #     single `*`) so it holds if GitHub ever serves a multi-label host.
+    # Cilium v1.19 supports `**`. Coding runs' own git clone/push (codeload.,
+    # ghcr.io, registries) run in the janet-coding sandbox ns, not here.
+    - toFQDNs:
+        - matchName: "github.com"
+        - matchPattern: "**.github.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
## Problem
"Connect GitHub" fails at the OAuth token exchange — the brain can't reach GitHub:

```
github exchange failed: Post "https://github.com/login/oauth/access_token":
dial tcp 140.82.113.3:443: connect: connection timed out
```

The brain's `janet-brain-egress` CiliumNetworkPolicy is default-deny (it holds the token vault + DB creds), and GitHub wasn't in the allow-list.

## Fix
Add a `toFQDNs` egress rule (port 443) for GitHub. Two non-overlapping entries, both needed:
- **`matchName: github.com`** — the OAuth token exchange/refresh endpoint (`github.com/login/oauth/access_token`) lives on the **bare apex**. A wildcard pattern never matches the apex, so it's listed explicitly.
- **`matchPattern: "**.github.com"`** — `api.github.com` (App/user API, the only subdomain the brain code dials). `**` (not single `*`) so it holds for any future multi-label host; Cilium v1.19.5 on fairy supports it.

Coding runs' own git clone/push (`codeload.github.com`, `ghcr.io`, registries) will run in the `janet-coding` sandbox namespace (§2), not from the brain, so they're out of scope here.

DNS is already cluster-intercepted (the intercept-all-dns CCNP), so Cilium learns the FQDN→IP mappings — no separate DNS rule needed. First OAuth attempt after rollout may briefly race until the mapping is cached; a retry resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file network policy change that only opens HTTPS to GitHub hosts the brain already needs for OAuth; no application or vault logic changes.
> 
> **Overview**
> Fixes **Connect GitHub** failing when the brain exchanges OAuth codes: default-deny egress on `janet-brain-egress` had no GitHub destinations, so `POST https://github.com/login/oauth/access_token` timed out.
> 
> Adds a new **`toFQDNs`** block on **TCP 443** with **`matchName: github.com`** (apex OAuth token endpoint) and **`matchPattern: "**.github.com"`** (e.g. `api.github.com`). Git clone/codeload/ghcr remain out of scope for the brain namespace per existing design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9ab720aa45f954d6d70528b5d61decc803a399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->