### PR TITLE
revert(bazarr): pin back to 1.5.6 (1.6.0 alembic migration break)

### DIFF
--- a/kubernetes/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/bazarr
-              tag: 1.6.0@sha256:cd63bbd0986c93e238eb8b9442604d249f0d4080099b389f822abe2062044417
+              tag: 1.5.6@sha256:80cb090162b47ea1bfb499d742b45a460b282f17ffefa4c01d518a5c8d52a5a4
             env:
               TZ: America/Chicago
             ports:


### PR DESCRIPTION
Reverts the image bump from #2052.

## Why
bazarr `1.6.0` (home-operations image) crash-loops on startup on atlantis:

```
flask_migrate ERROR - Error: Can't locate revision identified by '7e9a2b1c4d5f'
```

The config DB is stamped with an Alembic revision that 1.6.0's bundled migration scripts don't contain, so flask-migrate aborts **before** the app starts. Because it fails before touching data, the DB is intact and `1.5.6` (which matches the stamped revision) starts cleanly again.

## Follow-up
Hold 1.6.0 until the migration path is understood — likely needs a later home-operations tag (upstream may have fixed the migration chain post-1.6.0) or a manual `alembic stamp` performed against a volsync snapshot of the config PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-image rollback in a media app HelmRelease; no auth or data migration changes, and the revert restores a known-good version.
> 
> **Overview**
> **Reverts** the Bazarr container image in `helmrelease.yaml` from **1.6.0** back to **1.5.6**, including the matching digest pin on `ghcr.io/home-operations/bazarr`.
> 
> This undoes the bump from #2052 because **1.6.0** crash-loops on startup when the config DB is already stamped with an Alembic revision (`7e9a2b1c4d5f`) that isn’t in that image’s migration set; **1.5.6** aligns with the existing DB and starts normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108552b84e4c2b712e22d8a28e03073d62c17120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->