### PR TITLE
fix(bazarr): roll forward to 1.6.0 + raise HR timeout (recover from migration wedge)

### DIFF
--- a/kubernetes/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/helmrelease.yaml
@@ -9,6 +9,10 @@ spec:
     kind: OCIRepository
     name: app-template
     namespace: default
+  # 1.6.0 does a large first-boot SQLite schema refactor; give helm room so the
+  # migration isn't aborted mid-flight (which previously triggered a rollback to
+  # an image that can't read the already-migrated DB).
+  timeout: 15m
   install:
     remediation:
       retries: -1
@@ -30,7 +34,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/bazarr
-              tag: 1.5.6@sha256:80cb090162b47ea1bfb499d742b45a460b282f17ffefa4c01d518a5c8d52a5a4
+              tag: 1.6.0@sha256:cd63bbd0986c93e238eb8b9442604d249f0d4080099b389f822abe2062044417
             env:
               TZ: America/Chicago
             ports:


### PR DESCRIPTION
Recovers bazarr after the #2052 → #2057 sequence.

## Root cause
bazarr 1.6.0's first boot migrated the config DB forward to Alembic revision `7e9a2b1c4d5f` (a large schema refactor — subtitles moved to dedicated tables). Helm's wait then timed out during that migration and remediated by rolling the release back to 1.5.6 **mid-flight**. 1.5.6 cannot read the already-migrated DB, so it crash-loops with `Can't locate revision '7e9a2b1c4d5f'` — and so did the #2057 revert. The DB is already at 1.6.0's schema; the only way out is forward.

## Fix
- Re-pin the image to `1.6.0@sha256:cd63bbd…` (revert of #2057).
- Add `spec.timeout: 15m` so a first-boot migration can't be aborted mid-flight again.

Migration is already complete, so 1.6.0 should boot cleanly on re-apply. A pre-1.6.0 volsync snapshot (~17:33) exists as a fallback if forward recovery fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Single-app media workload with a one-way DB schema; wrong timeout or image pin could repeat crash-loops, but scope is limited to Bazarr’s PVC-backed config.
> 
> **Overview**
> **Forward-recovers Bazarr** after a failed upgrade left the config SQLite DB on 1.6.0’s schema while the cluster was rolled back to **1.5.6**, which cannot start against that revision.
> 
> The `helmrelease.yaml` changes **re-pin** `ghcr.io/home-operations/bazarr` from **1.5.6** to **1.6.0** (`sha256:cd63bbd…`) and add **`spec.timeout: 15m`** (with inline comments) so Helm’s wait does not time out during 1.6.0’s heavy first-boot migration and trigger remediation back to an incompatible image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93bcd3229aab509b16463d89243f25707311826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->