### PR TITLE
fix(bazarr): add startup probe (real fix for 1.6.0 crash-loop)

### DIFF
--- a/kubernetes/apps/media/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/helmrelease.yaml
@@ -41,6 +41,19 @@ spec:
               - name: http
                 containerPort: &port 6767
             probes:
+              # Startup probe gates liveness/readiness so a slow first boot
+              # (1.6.0's schema init) isn't SIGTERM'd at 30s. Allows ~5 min.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 2
+                  failureThreshold: 60
               liveness: &probes
                 enabled: true
                 custom: true


### PR DESCRIPTION
The actual root cause behind the bazarr crash-loop.

## Diagnosis
The 1.6.0 pod clears the DB migration and reaches app init, then is **SIGTERM'd (exit 143) at exactly 30s** on every restart. The liveness probe — `initialDelaySeconds: 0`, `periodSeconds: 10`, `failureThreshold: 3` — kills the container 30s after start if `/health` isn't serving yet. 1.6.0's first-boot init takes longer than 30s, so liveness kills it mid-startup, forever. (1.5.6 started just under 30s, which is why it was never hit.)

## Fix
Add a **startup probe** (`/health`, up to ~5 min) that gates liveness/readiness until the app is genuinely up. The image bump and DB migration are fine — this probe timing was the whole problem.

Follows #2059 (roll-forward to 1.6.0) and supersedes the earlier revert #2057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-app Helm probe tuning with no auth, data model, or image changes in this diff; mis-tuned probes could delay failure detection but mirror patterns used elsewhere in the repo.
> 
> **Overview**
> Fixes Bazarr **1.6.0** crash-looping on first boot by adding a **startup probe** on `/health` before the existing liveness/readiness checks.
> 
> The startup probe uses a **5s period** and **failureThreshold: 60** (~5 minutes total) so Kubernetes won't treat the container as failed while 1.6.0 runs its slow initial SQLite schema work. Until startup succeeds, **liveness and readiness are gated**, avoiding the prior ~30s SIGTERM when `/health` wasn't up yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951ddac6760c8b3b01ac052fadae4ef5b3be3a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->