### PR TITLE
feat(janet): platform prep for OCI-manifests cutover — prune off + OCIRepository/ImageRepository/ImagePolicy

### DIFF
--- a/kubernetes/apps/flux/image-automation/imagepolicy-janet-manifests.yaml
+++ b/kubernetes/apps/flux/image-automation/imagepolicy-janet-manifests.yaml
@@ -1,0 +1,29 @@
+---
+# Selects the latest janet-brain manifests tag matching `main-<ISO8601-compact-UTC>-<sha>`.
+# Extracts the timestamp and picks numerically highest (= most recent build).
+# Marker: # {"$imagepolicy": "flux-system:janet-manifests:tag"}
+# (set on kubernetes/apps/inference/janet/platform/ocirepository.yaml).
+#
+# When the janet-brain repo cuts semver releases (v0.x.y), add a second
+# policy beside this one with `policy.semver` and decide which channel the
+# OCIRepository tracks (main builds vs releases).
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: janet-manifests
+spec:
+  imageRepositoryRef:
+    name: janet-manifests
+    # Same namespace (flux-system) as this policy + the automation — no
+    # cross-namespace accessFrom needed. See imagerepository-janet-manifests.yaml
+    # for why this scanner lives here rather than beside the OCIRepository on
+    # fairy (accessFrom ACLs don't span clusters).
+    namespace: flux-system
+  filterTags:
+    pattern: '^main-(?P<ts>[0-9]{8}T[0-9]{6}Z)-[a-f0-9]+$'
+    extract: '$ts'
+  policy:
+    # Fixed-width ISO 8601 compact UTC (YYYYMMDDTHHMMSSZ) is lex-sortable —
+    # alphabetical ascending = chronological. Latest = highest.
+    alphabetical:
+      order: asc

--- a/kubernetes/apps/flux/image-automation/imagerepository-janet-manifests.yaml
+++ b/kubernetes/apps/flux/image-automation/imagerepository-janet-manifests.yaml
@@ -1,0 +1,25 @@
+---
+# Scans the janet-brain manifests OCI registry so the ImageUpdateAutomation
+# can track new builds. Lives in flux-system on atlantis (the only cluster
+# running the committer), even though the OCIRepository that actually pulls
+# these manifests runs on fairy (see
+# kubernetes/apps/inference/janet/platform/ocirepository.yaml) — the marker
+# rewrite is a git operation, so the scanner just needs to live wherever the
+# automation reads its ImagePolicies. Same placement rationale as this
+# directory's existing imagerepository-janet-brain.yaml (the container image
+# scanner for the same app).
+#
+# Reuses harvest-ghcr-login: the same shared GHCR read PAT (1Password
+# hedgehog-ghcr) reads both freckleapps org packages and the personal
+# nicolerenee packages, so one docker-config secret covers all flux-system
+# scanners.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/image.toolkit.fluxcd.io/imagerepository_v1.json
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: janet-manifests
+spec:
+  image: ghcr.io/freckleapps/janet-manifests
+  interval: 5m
+  secretRef:
+    name: harvest-ghcr-login

--- a/kubernetes/apps/flux/image-automation/kustomization.yaml
+++ b/kubernetes/apps/flux/image-automation/kustomization.yaml
@@ -6,7 +6,9 @@ resources:
   - ./ghcr-login.externalsecret.yaml
   - ./imagerepository-harvest.yaml
   - ./imagerepository-janet-brain.yaml
+  - ./imagerepository-janet-manifests.yaml
   - ./imagepolicy-hedgehog.yaml
   - ./imagepolicy-harvest.yaml
   - ./imagepolicy-janet-brain.yaml
+  - ./imagepolicy-janet-manifests.yaml
   - ./imageupdateautomation.yaml

--- a/kubernetes/apps/inference/janet/platform/kustomization.yaml
+++ b/kubernetes/apps/inference/janet/platform/kustomization.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+# Deliberately NOT mirroring hedgehog's platform dir 1:1:
+#
+# - No imagerepository.yaml here. Hedgehog is single-cluster (atlantis), so
+#   its ImageRepository can live beside its OCIRepository and still use
+#   `accessFrom` for the flux-system ImagePolicy on the *same* cluster.
+#   janet-brain spans two clusters — workloads on fairy, but
+#   ImageUpdateAutomation (the git-committing automation) only runs on
+#   atlantis to avoid two committers racing (see
+#   kubernetes/clusters/atlantis-k8s01/flux/image-automation.yaml). A
+#   cross-namespace `accessFrom` ACL only works within one cluster's API
+#   server, so an ImageRepository created here (fairy) could never be
+#   referenced by an ImagePolicy on atlantis. Instead, the scanner lives
+#   directly in flux-system on atlantis, matching the *existing* precedent
+#   for janet-brain's own container image
+#   (kubernetes/apps/flux/image-automation/imagerepository-janet-brain.yaml):
+#   see imagerepository-janet-manifests.yaml + imagepolicy-janet-manifests.yaml
+#   in that same directory. Both reuse the `harvest-ghcr-login` secret
+#   that's already there — no new secret needed.
+#
+# - No Receiver / image-receiver ExternalSecret here either. fairy-k8s01
+#   does run the shared Flux notification-controller webhook (Tailscale
+#   funnel Ingress from kubernetes/apps/flux/instance/webhook/, same as
+#   atlantis), but a per-app push-trigger Receiver would need to live
+#   alongside the ImageRepository it annotates — which, per the point
+#   above, is on atlantis, not here. janet-brain's own container-image
+#   scanner has never had a push Receiver either (poll-only, same as
+#   this one will be). Adding a webhook push-trigger is a reasonable
+#   future optimization but isn't required for correctness: the
+#   ImageRepository's 5m poll interval is the delivery path for now.

--- a/kubernetes/apps/inference/janet/platform/ocirepository.yaml
+++ b/kubernetes/apps/inference/janet/platform/ocirepository.yaml
@@ -1,0 +1,33 @@
+---
+# Source for janet-brain's kustomize manifests. The app repo publishes an OCI
+# artifact at build time alongside the container image; both share the same
+# tag so a build advances them atomically (see hedgehog's identical pattern
+# at kubernetes/apps/hedgehog/platform/ocirepository.yaml).
+#
+# PR 1 (this file): stand up the source only. Nothing consumes it yet — the
+# janet-brain/janet-migrate Kustomizations still source from GitRepository.
+# PR 2 swaps their sourceRef to this OCIRepository.
+#
+# Tag strategy: immutable `main-<ISO8601-compact-UTC>-<short-sha>` tags, same scheme as
+# the janet-brain image tags. The marker comment below lets
+# image-automation-controller rewrite `ref.tag` automatically — see
+# kubernetes/apps/flux/image-automation/imagepolicy-janet-manifests.yaml.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: janet
+spec:
+  interval: 5m
+  url: oci://ghcr.io/freckleapps/janet-manifests
+  ref:
+    tag: main-20260705T072702Z-d135b74 # {"$imagepolicy": "flux-system:janet-manifests:tag"}
+  secretRef:
+    # Reuses the cluster-wide `ghcr-pull` dockerconfigjson secret already
+    # materialized in this namespace (ClusterExternalSecret gated on the
+    # `freckle.systems/ghcr-pull: "true"` namespace label — see
+    # kubernetes/clusters/fairy-k8s01/flux/janet.yaml and
+    # kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/clusterexternalsecret.yaml).
+    # It's the same kubernetes.io/dockerconfigjson shape as hedgehog's
+    # self-owned `ghcr-login-secret`, so there's no need to stand up a
+    # second GHCR ExternalSecret in this namespace just for manifest pulls.
+    name: ghcr-pull

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/brain.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/brain.yaml
@@ -28,5 +28,7 @@ spec:
   interval: 2m
   retryInterval: 1m
   timeout: 5m
-  prune: true
+  # prune deliberately disabled ahead of the OCI-artifact cutover so deleting
+  # this KS (PR 2) adopts the existing resources instead of garbage-collecting them.
+  prune: false
   wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml
+  - ./platform.yaml
   - ./db.yaml
   - ./migrate.yaml
   - ./brain.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/migrate.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/migrate.yaml
@@ -25,6 +25,8 @@ spec:
   interval: 2m
   retryInterval: 1m
   timeout: 5m
-  prune: true
+  # prune deliberately disabled ahead of the OCI-artifact cutover so deleting
+  # this KS (PR 2) adopts the existing resources instead of garbage-collecting them.
+  prune: false
   # Wait for the Job to complete before dependents (the brain) roll.
   wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/platform.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/platform.yaml
@@ -1,0 +1,38 @@
+---
+# Platform-side scaffolding: OCIRepository pointing at the manifest bundle
+# published by the janet-brain app repo. Mirrors hedgehog's platform.yaml
+# (kubernetes/clusters/atlantis-k8s01/apps/hedgehog/platform.yaml) — see
+# kubernetes/apps/inference/janet/platform/kustomization.yaml for where this
+# one deliberately diverges (no ImageRepository/Receiver in this dir).
+#
+# PR 1 (this file): stands up the source only, unconsumed. PR 2 points
+# janet-brain/janet-migrate's sourceRef at this OCIRepository.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app janet-platform
+  namespace: &namespace janet
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  # external-secrets: not because this dir creates an ExternalSecret (it
+  # doesn't — the OCIRepository reuses the pre-existing `ghcr-pull` secret),
+  # but for consistency with the other janet-namespace KSs (db/migrate/brain
+  # all dependsOn external-secrets) and because the ghcr-pull Secret itself
+  # is materialized by the ESO ClusterExternalSecret machinery.
+  dependsOn:
+    - name: external-secrets
+      namespace: external-secrets
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/inference/janet/platform
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: true


### PR DESCRIPTION
PR 1 of 2 for moving janet's manifests to the app-repo OCI artifact (freckleapps/janet-brain#56 published the bundle; first tag `main-20260705T072702Z-d135b74`). This PR is deliberately consumption-free: it defuses prune and stands up the source + automation plumbing. PR 2 does the atomic swap.

## What

- **`prune: false`** on the existing `janet-brain` / `janet-migrate` git Kustomizations — the critical safety step so PR 2's deletion of these KS objects adopts resources instead of garbage-collecting the app.
- **`kubernetes/apps/inference/janet/platform/`** (new, fairy): OCIRepository `janet` → `oci://ghcr.io/freckleapps/janet-manifests`, pinned to the first published tag with the `flux-system:janet-manifests:tag` image-automation marker. Auth reuses the namespace's existing `ghcr-pull` dockerconfigjson (no new ExternalSecret; covers all of freckleapps/*).
- **`janet-platform` Flux KS** wiring the dir in (`clusters/fairy-k8s01/apps/janet/platform.yaml`).
- **`kubernetes/apps/flux/image-automation/`** (atlantis flux-system): ImageRepository + ImagePolicy for `janet-manifests`, same `^main-<ts>-<sha>$` alphabetical-asc pattern, reusing `harvest-ghcr-login`. The existing `janet-brain` image policy/repo stay until PR 2.

## Deliberate deviations from the hedgehog mirror (documented in-repo)

- The manifests scanner lives in atlantis flux-system, not beside the fairy OCIRepository: the git-committing ImageUpdateAutomation runs on atlantis and `accessFrom` ACLs don't span clusters — same precedent as janet-brain's existing image scanner.
- No Receiver: janet's image automation has always been poll-only (5m); the app repo's CI webhook step soft-skips until a receiver exists. Reasonable future add, not required.

## Verification

- `kustomize build` green on all touched dirs; the repo's own validators (`validate-kustomizations`, `validate-schema-alignment`, `validate-repository`) pass 6/6 (134/134 kustomizations).
- Nothing consumes the OCIRepository yet — after merge, `flux get sources oci -n janet` going Ready is the pull-access canary for the private package ahead of PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Flux delivery for janet (prune off, new OCI source and tag automation) ahead of a cutover; runtime unchanged until PR 2 but mis-merge could affect adoption/prune behavior at swap time.
> 
> **Overview**
> **PR 1 of 2** for moving janet workloads from git-sourced manifests to the app-repo OCI bundle (`ghcr.io/freckleapps/janet-manifests`). Nothing switches consumers yet; this lands plumbing and a safety change ahead of PR 2’s atomic `sourceRef` swap.
> 
> Sets **`prune: false`** on the existing `janet-brain` and `janet-migrate` Flux Kustomizations so removing those KS objects in PR 2 **adopts** live resources instead of pruning them.
> 
> Adds **`janet-platform`** on fairy-k8s01 and **`kubernetes/apps/inference/janet/platform/`** with an **`OCIRepository` `janet`** pinned to the first published tag and an image-automation marker on `ref.tag`, using the namespace’s existing **`ghcr-pull`** secret.
> 
> Registers **`ImageRepository` + `ImagePolicy` `janet-manifests`** in atlantis **`flux-system`** (same `main-<ts>-<sha>` alphabetical policy as janet-brain, **`harvest-ghcr-login`**) so ImageUpdateAutomation can rewrite the OCI tag in git—scanner lives on atlantis because the committer runs there, not beside the fairy OCI source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cca87ca66a91f52c5657d8bd9530b2871fd260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->