### PR TITLE
feat(janet): janet-coding sandbox namespace + controller Flux Kustomization

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/apps/janet/controller.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/controller.yaml
@@ -1,0 +1,42 @@
+---
+# janet-controller: the background-coding-run supervisor. Sources the ./coding
+# subpath of the janet OCI manifest bundle (published by the app repo alongside
+# ./workloads + ./migrate).
+#
+# Unlike janet-brain/janet-migrate this KS sets NO targetNamespace: the bundle
+# spans two namespaces — the Deployment/Service/SA + egress policy in `janet`,
+# the Role/RoleBinding in `janet-coding` — and each manifest pins its own
+# namespace. A targetNamespace would flatten them all into one.
+#
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app janet-controller
+  namespace: janet
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets
+      namespace: external-secrets
+    # The OCIRepository this KS sources from is created by janet-platform.
+    - name: janet-platform
+      namespace: janet
+    # The controller reads the coding_runs + River tables — wait for migrations
+    # (janet-migrate transitively waits for janet-db).
+    - name: janet-migrate
+      namespace: janet
+  sourceRef:
+    kind: OCIRepository
+    name: janet
+    namespace: janet
+  path: ./coding
+  interval: 2m
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./db.yaml
   - ./migrate.yaml
   - ./brain.yaml
+  - ./controller.yaml

--- a/kubernetes/clusters/fairy-k8s01/flux/janet.yaml
+++ b/kubernetes/clusters/fairy-k8s01/flux/janet.yaml
@@ -10,6 +10,25 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  # The sandbox namespace: janet-controller creates one short-lived Job per
+  # background coding run here (nothing long-running lives in it). Isolated from
+  # `janet` for a hard k8s boundary around code the runner executes.
+  name: janet-coding
+  labels:
+    # The runner image is private — fan the `ghcr-pull` secret in here too.
+    freckle.systems/ghcr-pull: "true"
+    # Enforce the restricted Pod Security Standard: the runner Jobs run untrusted
+    # harness code, so admission must reject anything not nonroot / no-privesc /
+    # caps-dropped (the controller's BuildJob already emits a compliant pod).
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
 # yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/kubernetes/clusters/fairy-k8s01/flux/janet.yaml
+++ b/kubernetes/clusters/fairy-k8s01/flux/janet.yaml
@@ -20,9 +20,11 @@ metadata:
   labels:
     # The runner image is private — fan the `ghcr-pull` secret in here too.
     freckle.systems/ghcr-pull: "true"
-    # Enforce the restricted Pod Security Standard: the runner Jobs run untrusted
-    # harness code, so admission must reject anything not nonroot / no-privesc /
-    # caps-dropped (the controller's BuildJob already emits a compliant pod).
+    # Enforce the restricted Pod Security Standard (the strictest tier): the runner
+    # Jobs run untrusted harness code, so admission rejects any pod that isn't fully
+    # hardened per that profile — nonroot, no privilege escalation, capabilities
+    # dropped, a seccomp profile, no host namespaces/paths, and more (non-exhaustive;
+    # see the PSS spec). The controller's BuildJob already emits a compliant pod.
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
Wires the deploy side of janet's background coding runs into the fairy cluster.

## What
- **`flux/janet.yaml`**: add the **`janet-coding`** Namespace — an isolated k8s boundary for the short-lived Jobs janet-controller launches per coding run (they execute untrusted harness code). **restricted PSS** (enforce/audit/warn) so admission rejects any non-nonroot / privesc / capability-bearing pod; **ghcr-pull** label so the private runner image pulls there.
- **`apps/janet/controller.yaml`**: a Flux Kustomization sourcing the **`./coding`** subpath of the janet OCI bundle. Deliberately **no `targetNamespace`** — the bundle spans `janet` (controller Deployment/Service/SA + egress policy) and `janet-coding` (the controller's Role/RoleBinding), and each manifest pins its own namespace. `dependsOn` external-secrets + janet-platform (the OCIRepository) + janet-migrate.
- **`apps/janet/kustomization.yaml`**: register it.

## Pairs with
The app-repo manifests it points at (controller Deployment, RBAC, Service, Cilium egress) land in `freckleapps/janet-brain#67`. Once both merge and the OCI bundle publishes, the controller comes up and coding runs execute (echo harness; opencode stays gated until the seccomp profile lands).

## Notes
- Least-privilege: the controller's RBAC (in the app bundle) is a namespaced Role in `janet-coding` only, never a ClusterRole.
- `kustomize build` on `apps/janet` passes with the new KS.
- Unrelated working-tree WIP in this repo was left untouched — this branch only touches the three janet files above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables infrastructure for untrusted code in isolated Jobs; risk is mitigated by a separate namespace and restricted PSS, but correctness depends on the paired app-repo manifests and controller Job hardening.
> 
> **Overview**
> Deploys **janet-controller** on fairy by adding a Flux Kustomization that applies the janet OCI bundle’s **`./coding`** path, with **`dependsOn`** on external-secrets, janet-platform, and janet-migrate. Unlike **janet-brain**, this KS **omits `targetNamespace`** so manifests can land in both **`janet`** (controller) and **`janet-coding`** (Job RBAC).
> 
> Introduces the **`janet-coding`** namespace as an isolated sandbox for short-lived coding-run Jobs: **`ghcr-pull`** for the private runner image and **restricted Pod Security Standards** (enforce/audit/warn) so non-hardened pods are rejected at admission.
> 
> Registers the new KS in **`apps/janet/kustomization.yaml`** so it rolls out with the rest of the janet app stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5b7a76d1b65e189bb7ff8f0e8f71bd228ca3fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->