### PR TITLE
feat(fairy/talos): node-local seccomp profile for the janet-coding sandbox

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/talos/talconfig.yaml
+++ b/kubernetes/clusters/fairy-k8s01/talos/talconfig.yaml
@@ -66,15 +66,42 @@ nodes:
           - vlanId: 300
             mtu: 1500
             dhcp: false
-            # Kernel requires an IPv4 address on the VLAN subinterface for
-            # macvlan child TX to work. Using TEST-NET-3 (RFC 5737) as a
-            # dummy address that will never be routed.
-            addresses:
-              - 203.0.113.1/32
+            # No address: bond0.300 is purely a bridge port for br300.
+            # (The earlier dummy 203.0.113.1/32 placeholder existed to
+            # nudge Cilium's auto-detect into adding VLAN 300 to its
+            # bpf VLAN allow-list. That's now done explicitly via
+            # `bpf.vlanBypass: [300]` in the Cilium Helm values, so the
+            # placeholder is no longer needed.)
+      - &cn01-br300
+        # L2 bridge over VLAN 300 (home LAN). Used as the parent for
+        # KubeVirt VM bridge-CNI attachments and macvlan pod attachments
+        # (multus-trusted, multus-vm-trusted). The bridge holds no IP —
+        # it's purely an L2 fanout. STP disabled (single port = no loops).
+        #
+        # The MAC is pinned per node via an inline patch on each cn
+        # node's `patches:` list (talhelper doesn't pass `hardwareAddr`
+        # through to BridgeConfig). Scheme: 02:1f:80:03:00:NN —
+        # locally-administered (02), random vendor-like prefix (1f:80),
+        # VLAN ID 300 as 03:00, NN = cn-node number. Without pinning
+        # the kernel synthesizes a random MAC each boot (observed
+        # 16:f4:… → 0e:da:… across a single reboot).
+        interface: br300
+        dhcp: false
+        mtu: 1500
+        bridge:
+          stp:
+            enabled: false
+          interfaces:
+            - bond0.300
     patches:
       - ./patches/bridge-sysctls.yaml
       - ./patches/tpm-encryption.yaml
       - ./patches/watchdog.yaml
+      - |-
+        apiVersion: v1alpha1
+        kind: BridgeConfig
+        name: br300
+        hardwareAddr: "02:1f:80:03:00:01"
 
   - hostname: fairy-r02-cn02
     ipAddress: 10.189.3.17
@@ -92,10 +119,16 @@ nodes:
       - <<: *cn01-10g-1
         addresses:
           - 10.189.3.17/24
+      - <<: *cn01-br300
     patches:
       - ./patches/bridge-sysctls.yaml
       - ./patches/tpm-encryption.yaml
       - ./patches/watchdog.yaml
+      - |-
+        apiVersion: v1alpha1
+        kind: BridgeConfig
+        name: br300
+        hardwareAddr: "02:1f:80:03:00:02"
 
   - hostname: fairy-r02-cn03
     ipAddress: 10.189.3.18
@@ -113,10 +146,16 @@ nodes:
       - <<: *cn01-10g-1
         addresses:
           - 10.189.3.18/24
+      - <<: *cn01-br300
     patches:
       - ./patches/bridge-sysctls.yaml
       - ./patches/tpm-encryption.yaml
       - ./patches/watchdog.yaml
+      - |-
+        apiVersion: v1alpha1
+        kind: BridgeConfig
+        name: br300
+        hardwareAddr: "02:1f:80:03:00:03"
 
   - hostname: fairy-r02-cn04
     ipAddress: 10.189.3.19
@@ -134,10 +173,16 @@ nodes:
       - <<: *cn01-10g-1
         addresses:
           - 10.189.3.19/24
+      - <<: *cn01-br300
     patches:
       - ./patches/bridge-sysctls.yaml
       - ./patches/tpm-encryption.yaml
       - ./patches/watchdog.yaml
+      - |-
+        apiVersion: v1alpha1
+        kind: BridgeConfig
+        name: br300
+        hardwareAddr: "02:1f:80:03:00:04"
 
   - hostname: fairy-r02-cn05
     ipAddress: 10.189.3.20
@@ -155,10 +200,16 @@ nodes:
       - <<: *cn01-10g-1
         addresses:
           - 10.189.3.20/24
+      - <<: *cn01-br300
     patches:
       - ./patches/bridge-sysctls.yaml
       - ./patches/tpm-encryption.yaml
       - ./patches/watchdog.yaml
+      - |-
+        apiVersion: v1alpha1
+        kind: BridgeConfig
+        name: br300
+        hardwareAddr: "02:1f:80:03:00:05"
 
   - hostname: fairy-r02-cn06
     ipAddress: 10.189.3.21
@@ -176,10 +227,16 @@ nodes:
       - <<: *cn01-10g-1
         addresses:
           - 10.189.3.21/24
+      - <<: *cn01-br300
     patches:
       - ./patches/bridge-sysctls.yaml
       - ./patches/tpm-encryption.yaml
       - ./patches/watchdog.yaml
+      - |-
+        apiVersion: v1alpha1
+        kind: BridgeConfig
+        name: br300
+        hardwareAddr: "02:1f:80:03:00:06"
 
   - hostname: fairy-r02-dgx01
     ipAddress: 10.189.3.22
@@ -431,6 +488,28 @@ controlPlane:
         time:
           servers:
           - time.cloudflare.com # leave it as cloudflare but the router will hijack this and respond
+        # Node-local seccomp profile for the janet-coding namespace's sandbox pods:
+        # denies the cross-process memory-read syscalls (ptrace, process_vm_readv/
+        # writev, process_madvise, kcmp). Talos writes it to
+        # /var/lib/kubelet/seccomp/profiles/janet-no-ptrace.json; pods select it via
+        # localhostProfile: profiles/janet-no-ptrace.json.
+        seccompProfiles:
+          - name: janet-no-ptrace.json
+            value:
+              defaultAction: SCMP_ACT_ALLOW
+              architectures:
+                - SCMP_ARCH_X86_64
+                - SCMP_ARCH_X86
+                - SCMP_ARCH_X32
+              syscalls:
+                - names:
+                    - ptrace
+                    - process_vm_readv
+                    - process_vm_writev
+                    - process_madvise
+                    - kcmp
+                  action: SCMP_ACT_ERRNO
+                  errnoRet: 1
 worker:
   patches:
     - *disableSearchDomainPatch


### PR DESCRIPTION
## Primary change — seccomp profile
Adds a `machine.seccompProfiles` entry (`janet-no-ptrace.json`) to the shared `*machinePatches` block, so it applies to all nodes. It denies the cross-process memory-read syscalls (`ptrace`, `process_vm_readv`/`writev`, `process_madvise`, `kcmp`). Talos writes it to `/var/lib/kubelet/seccomp/profiles/janet-no-ptrace.json` on each node; pods in the `janet-coding` namespace select it via `localhostProfile: profiles/janet-no-ptrace.json`.

**Needs a talhelper regen + Talos config apply** to land on the nodes.

## Also included (pre-existing working-tree WIP — Nicole's, reviewed)
This branch also carries in-flight `talconfig.yaml` changes that were already uncommitted in the working tree, unrelated to the seccomp profile:
- **br300 / VLAN 300 bridge** config — a `bond0.300` bridge port for `br300` (L2 fanout for KubeVirt/macvlan attachments), with per-node MAC pinning, and dropping the old `203.0.113.1/32` placeholder now that `bpf.vlanBypass: [300]` handles the Cilium VLAN allow-list explicitly.

Bundled here intentionally (Nicole confirmed). Flagging for review clarity so the seccomp diff isn't the only thing in the file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches live node networking on all compute nodes (VLAN/bridge topology) and node-level sandbox syscall policy; mis-apply or MAC/bridge mistakes could break home-LAN workloads or break janet-coding pods that expect ptrace.
> 
> **Overview**
> Adds a cluster-wide Talos **`janet-no-ptrace.json`** seccomp profile in the shared `*machinePatches` block so kubelet materializes it on every node; **`janet-coding`** sandbox pods can opt in via `localhostProfile: profiles/janet-no-ptrace.json` to block cross-process memory inspection syscalls (`ptrace`, `process_vm_*`, `process_madvise`, `kcmp`).
> 
> On **cn01–cn06**, introduces **`br300`** as an L2 bridge on VLAN 300 (`bond0.300` as the only port, no IP on the VLAN subinterface) for KubeVirt/macvlan attachments, drops the old **`203.0.113.1/32`** placeholder on `bond0.300` now that Cilium **`bpf.vlanBypass: [300]`** covers the allow-list, and pins a stable **`br300` MAC per node** with inline `BridgeConfig` patches (`02:1f:80:03:00:NN`).
> 
> **Requires talhelper regen and Talos config apply** before either change is live on nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c347e44445dd4315d04c919c412eb859648be8a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->