### PR TITLE
fix(qwen36-35b-a3b): re-enable MTP spec decoding, fix rollout deadlock

### DIFF
--- a/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
+++ b/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
@@ -1,9 +1,12 @@
 ---
 # Qwen3.6-35B-A3B-FP8 served by vLLM, single-node (tp=1) per GB10. Two replicas
 # spread one-per-DGX-node (podAntiAffinity) form the HA pair; the in-cluster AI
-# gateway load-balances + health-checks across them. RollingUpdate keeps ≥1 pod
-# serving during deploys (needs a spare DGX GPU for the surge — true while a 3rd
-# local model isn't occupying dgx03).
+# gateway load-balances + health-checks across them. RollingUpdate surges a
+# replacement pod when a DGX node is free, but falls back to taking one
+# replica down first (briefly serving from just the other) when all DGX
+# nodes are occupied (e.g. a 3rd local model on dgx03) — the strict
+# one-pod-per-node podAntiAffinity means a surge pod can't schedule without
+# a free node, so this keeps the rollout from ever getting stuck.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,7 +16,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
+      maxUnavailable: 1
       maxSurge: 1
   selector:
     matchLabels:
@@ -89,9 +92,12 @@ spec:
             # froggeric honors this kwarg (defaults true anyway).
             - --default-chat-template-kwargs
             - '{"preserve_thinking": true}'
-            # NOTE: MTP speculative decoding (--speculative-config method=mtp) was
-            # dropped in the v0.24 consolidation — the move was validated without it;
-            # re-add + perf-test on v0.24 as a fast follow-up.
+            # MTP speculative decoding: the method is built into this checkpoint
+            # (no separate draft model needed). Worked fine on the prior v0.20
+            # image; re-enabled on v0.24 after the consolidation validated
+            # without it.
+            - --speculative-config
+            - '{"method":"mtp","num_speculative_tokens":1}'
             - --trust-remote-code
           env:
             - name: HF_HOME


### PR DESCRIPTION
## Summary
- Re-add `--speculative-config` (MTP, `num_speculative_tokens=1`) to the `vllm serve` command — dropped during the v0.24 consolidation to de-risk that rollout, but it worked fine on the prior v0.20 image, so re-enable it now.
- Change `strategy.rollingUpdate.maxUnavailable` from `0` to `1` (keep `maxSurge: 1`). The strict one-pod-per-node podAntiAffinity means a surge replacement pod needs a free DGX node; if all DGX nodes are occupied (e.g. a 3rd model on the spare node), the rollout could never schedule the surge pod and would get stuck. Allowing one replica down first frees its node for the replacement, so the rollout always makes progress — it still surges first (zero downtime) whenever a node is free.

Only `kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml` is touched.

## Test plan
- [x] `kustomize build kubernetes/apps/inference/models/qwen36-35b-a3b/` renders cleanly with both changes present (verified: `maxUnavailable: 1` and `--speculative-config`/`{"method":"mtp","num_speculative_tokens":1}` both present in rendered output).
- [ ] Not merging/rolling out yet — merging this will trigger a live rollout of the shared Qwen deployment, which should be watched manually before merge.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live two-replica inference deployment: rollouts may briefly run on a single replica when nodes are full, and re-enabled MTP decoding could change latency or stability on v0.24 until validated in production.
> 
> **Overview**
> Updates the **Qwen3.6-35B-A3B** vLLM `Deployment` so rollouts can finish under full DGX occupancy and MTP speculative decoding is turned back on.
> 
> **Rolling update:** `maxUnavailable` goes from **0** to **1** while `maxSurge` stays **1**. With required one-pod-per-node anti-affinity, a surge pod needs a free node; when every DGX is taken, allowing one replica down first frees a node so the replacement can schedule instead of the rollout hanging. When a node is free, behavior still prefers surge (no downtime).
> 
> **Inference:** Restores `--speculative-config` with `method: mtp` and `num_speculative_tokens: 1` on `vllm serve`, after it was removed for the v0.24 consolidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7b41f50be9cb399a46de23f3e46e33c6a695eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->