### PR TITLE
fix(flux): grant janet flux-receiver secret accessor (flux-system-scoped)

### DIFF
--- a/kubernetes/apps/flux/image-automation/receiver-janet-manifests.externalsecret.yaml
+++ b/kubernetes/apps/flux/image-automation/receiver-janet-manifests.externalsecret.yaml
@@ -23,4 +23,4 @@ spec:
   data:
     - secretKey: token
       remoteRef:
-        key: atlantis-k8s01-flux-system-flux-receiver-janet
+        key: flux-receiver-janet

--- a/tofu/janet-flux-receiver.tf
+++ b/tofu/janet-flux-receiver.tf
@@ -1,29 +1,49 @@
 # HMAC token for the janet-manifests Flux image-scan Receiver on atlantis. The
 # janet-brain publish workflow signs its webhook POST with this token and the
-# notification-controller verifies it, so a push forces an immediate tag scan
-# instead of waiting for the 5m ImageRepository poll. 32 random bytes (hex),
-# no hand-entry — stored in GSM and surfaced into flux-system by ESO via the
-# Receiver's ExternalSecret (kubernetes/apps/flux/image-automation/
+# notification-controller verifies it, forcing an immediate tag scan instead of
+# the 5m ImageRepository poll. 32 random bytes (hex), no hand-entry — surfaced
+# into flux-system by ESO (kubernetes/apps/flux/image-automation/
 # receiver-janet-manifests.externalsecret.yaml).
 #
+# Flat secret + explicit per-secret accessor, mirroring flux-github-app.tf. The
+# flux-system ESO reads GSM by per-secret IAM binding, NOT the gsm-secret
+# module's `<cluster>-<namespace>-*` prefix scheme — there is no eso-namespace
+# prefix grant for flux-system, so a module secret sync-errors on RBAC. The
+# accessor is limited to ONLY the flux-system ESO SA on atlantis; combined with
+# the namespace-scoped gcp-sm SecretStore, nothing outside flux-system can read it.
+#
 # The SAME value must be set as the FLUX_WEBHOOK_TOKEN GitHub Actions secret on
-# freckleapps/janet-brain (no github provider is wired into this tofu, so that
-# step is manual — read the value from GSM/`tofu output`). FLUX_WEBHOOK_URL is
-# the Receiver's runtime webhook path: https://atlantis-k8s01-flux-webhook.
-# <tailnet>/hook/<.status.webhookPath>.
+# freckleapps/janet-brain (no github provider in this tofu — manual). The
+# FLUX_WEBHOOK_URL is the Receiver's runtime path:
+# https://atlantis-k8s01-flux-webhook.<tailnet>/hook/<.status.webhookPath>.
 resource "random_bytes" "janet_flux_receiver" {
   length = 32
 }
 
-module "janet_flux_receiver_token" {
-  source = "./modules/gsm-secret"
+resource "google_secret_manager_secret" "janet_flux_receiver" {
+  secret_id = "flux-receiver-janet"
+  project   = local.project_id
 
-  cluster             = "atlantis-k8s01"
-  namespace           = "flux-system"
-  name                = "flux-receiver-janet"
-  secret_data         = random_bytes.janet_flux_receiver.hex
-  workload_project_id = local.project_id
-  extra_labels = {
+  labels = {
     consumer = "janet-brain"
+    purpose  = "flux-image-receiver"
   }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "janet_flux_receiver" {
+  secret      = google_secret_manager_secret.janet_flux_receiver.id
+  secret_data = random_bytes.janet_flux_receiver.hex
+}
+
+# Only the atlantis flux-system ESO SA may read it — the Receiver + janet-manifests
+# ImageRepository both live in flux-system on atlantis. Scoped to that one SA.
+resource "google_secret_manager_secret_iam_member" "janet_flux_receiver_accessor" {
+  project   = local.project_id
+  secret_id = google_secret_manager_secret.janet_flux_receiver.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "principal://iam.googleapis.com/projects/${data.google_project.iac.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.clusters.workload_identity_pool_id}/subject/system:serviceaccount:flux-system:external-secrets-atlantis-k8s01"
 }


### PR DESCRIPTION
Follow-up to #2071 — the janet flux-receiver ExternalSecret is `SecretSyncedError` because the `gsm-secret` module creates the secret but grants **no** IAM accessor (it assumes an `eso-namespace` prefix grant that doesn't exist for flux-system).

Fix mirrors `flux-github-app.tf`: flat GSM secret `flux-receiver-janet` + version (token value unchanged) + an explicit `secretAccessor` binding to **only** `system:serviceaccount:flux-system:external-secrets-atlantis-k8s01`; ExternalSecret `remoteRef.key` → `flux-receiver-janet`. Scoped to flux-system only (that one ESO SA + the namespace-scoped gcp-sm store).

After merge: `tofu apply` then the ExternalSecret syncs. No FLUX_WEBHOOK_TOKEN change (value unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 012bf9bd83da607e288771269cb75f398a257fe1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->