### PR TITLE
fix(ai-gateway): stop truncating long LLM streams (idle-based timeouts)

### DIFF
--- a/kubernetes/apps/inference/platform/ai-gateway/gateway.yaml
+++ b/kubernetes/apps/inference/platform/ai-gateway/gateway.yaml
@@ -36,6 +36,13 @@ spec:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: ai
+  # Reap a stream that goes 5 minutes with no upstream/downstream activity (a
+  # wedged backend or hung generation). Resets on every byte, so a healthy
+  # long-running LLM stream never trips it — this is the real safety net that
+  # lets the per-route request timeout be a loose 30m runaway backstop.
+  timeout:
+    http:
+      streamIdleTimeout: 300s
   connection:
     bufferLimit: 50Mi
 ---

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
@@ -63,3 +63,10 @@ spec:
       backendRefs:
         - name: local-qwen36-35b-a3b
           modelNameOverride: qwen3.6-35b-a3b
+      # Streaming LLM responses legitimately run several minutes; Envoy AI
+      # Gateway's implicit 60s request-timeout default truncated long single
+      # generations mid-stream. 30m is a runaway backstop a real turn never
+      # reaches — a genuinely stalled stream is reaped far sooner by the
+      # gateway-wide streamIdleTimeout (see ai-buffer-limit ClientTrafficPolicy).
+      timeouts:
+        request: 1800s


### PR DESCRIPTION
## Problem

Envoy AI Gateway applies an **implicit 60s `request` timeout** to the HTTPRoutes it generates from `AIGatewayRoute`s. `request` bounds the *entire* request/response cycle, so it force-closes any streaming response taking >60s — mid-stream, regardless of progress. At local-model speeds (~66 tok/s) that caps a single generation at **~4k output tokens**; anything longer is silently severed (HTTP 200 → `transfer closed`, surfacing to clients as *"stream disconnected before completion"*).

**Verified by direct repro** against the live gateway: a streamed generation cut at **exactly 61s, three-for-three**; the model server logs showed it generating normally at ~66 tok/s then the request aborted-by-client at the 60s mark — the truncation is the gateway's, not the backend's.

## Fix — idle-based reaper instead of a total-duration cap

The right tool for streaming is idle detection (is data flowing?), not total wall-clock:

- **`ClientTrafficPolicy/ai-buffer-limit`** (gateway-wide): `timeout.http.streamIdleTimeout: 300s`. Resets on every byte, so a healthy long stream never trips it; a genuinely stalled/wedged stream (no data for 5 min) is reaped. **This is the real safety net.**
- **`AIGatewayRoute/local-models`** (qwen): `timeouts.request: 1800s` — a loose **30-minute runaway backstop**. Each gateway request is one model turn (tool execution happens client-side *between* requests), so a legitimate single turn never approaches 30 min; this only ever fires on a degenerate/looping generation, which the idle timeout can't catch (tokens are still flowing). An explicit value is required — leaving it unset re-applies EAG's 60s default.

## Scope

This PR covers the two files not currently under other in-flight edits: the qwen route + the gateway-wide CTP. The **`anthropic` + `openai` routes** in `platform/ai-gateway/route.yaml` need the same `timeouts.request: 1800s` and are handled alongside the in-flight edits to that file.

## After merge / reconcile

Confirm the generated HTTPRoute actually reflects it (in case EAG treats zero/explicit values unexpectedly):

```
kubectl -n inference get httproute local-models -o jsonpath='{.spec.rules[0].timeouts}'
# expect {"request":"1800s"} — NOT {"request":"60s"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timeout behavior for all traffic on the internal AI gateway; misconfiguration could leave hung streams open longer or still truncate edge cases until other routes get the same request timeout.
> 
> **Overview**
> **Fixes mid-stream cutoffs** on long Qwen generations caused by Envoy AI Gateway’s implicit **60s per-request timeout**, which caps the whole response even when tokens are still flowing.
> 
> On the **`ai` gateway** (`ClientTrafficPolicy/ai-buffer-limit`), adds **`streamIdleTimeout: 300s`** so only streams with **no bytes for 5 minutes** are closed; active streams can run longer. On the fairy **`local-models`** Qwen rule, sets **`timeouts.request: 1800s`** as a **30-minute runaway backstop** (explicit value avoids the 60s default); normal turns stay under that, while truly wedged streams are still reaped by idle timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987c47da38bc09b266362a6800c18de5b4d47e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->