### PR TITLE
fix(victoria-logs): drop node_labels from log events (KubeVirt flood)

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
@@ -87,6 +87,11 @@ spec:
             source: |
               .log = parse_json(.message) ?? .message
               del(.message)
+              # KubeVirt stamps hundreds of node labels (cpu-feature/cpu-model/
+              # machine-type/hyperv.node.kubevirt.io/...) on every node, so each log
+              # line hauls the full set — the bulk of every line's bytes, and never
+              # useful for a log query (node identity is kept in pod_node_name).
+              del(.kubernetes.node_labels)
           audit-parser:
             type: remap
             inputs:


### PR DESCRIPTION
## Problem

Vector's `kubernetes_logs` source stamps the node's **entire label set** onto every log event. The fairy nodes run KubeVirt, which adds **hundreds** of labels per node — `cpu-feature.node.kubevirt.io/*`, `cpu-model-migration.*`, `machine-type.*`, `hyperv.*`, `host-model-required-features.*`, etc. So every single log line hauls all of them as `kubernetes.node_labels.*` fields; on a typical line that's ~90% of the bytes, and it's never useful for a log query.

## Fix

Drop `.kubernetes.node_labels` in the `parser` transform, before the VictoriaLogs sink:

```
del(.kubernetes.node_labels)
```

- Node identity is preserved via `kubernetes.pod_node_name`.
- `kubernetes.pod_labels` and `kubernetes.pod_annotations` are **kept** (those can matter).
- Applies to both clusters (shared helmrelease); reduces per-line size and VictoriaLogs field-index churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability pipeline tweak only—removes redundant indexed fields; no auth, app logic, or cluster control-plane behavior changes.
> 
> **Overview**
> Shrinks Victoria Logs ingestion by stripping **node label metadata** from Kubernetes log events in the shared Vector `parser` remap (after JSON parsing, before the VictoriaLogs sink).
> 
> Adds `del(.kubernetes.node_labels)` because KubeVirt-heavy nodes attach hundreds of `cpu-feature` / `machine-type` / `hyperv.*` labels that `kubernetes_logs` copies onto every line—mostly wasted bytes and index churn. **Pod labels and annotations are unchanged**; node identity still comes from `kubernetes.pod_node_name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4418f21ba21b6b492263999165627d743005c031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->