### PR TITLE
chore(janet): prune:false on child KSs (topology cutover prep, 1/2)

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/apps/janet/brain.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/brain.yaml
@@ -39,5 +39,9 @@ spec:
   interval: 2m
   retryInterval: 1m
   timeout: 5m
-  prune: true
+  # prune DISABLED ahead of the GitOps topology cutover — the app repo now owns
+  # the Kustomization topology (deploy/flux/). When the swap PR removes this KS
+  # file, the parent prunes THIS Kustomization object; with prune:false its
+  # workloads are orphaned (not GC'd) so the bundle-defined janet-api KS adopts them.
+  prune: false
   wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/controller.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/controller.yaml
@@ -38,5 +38,9 @@ spec:
   interval: 2m
   retryInterval: 1m
   timeout: 5m
-  prune: true
+  # prune DISABLED ahead of the GitOps topology cutover — the app repo now owns
+  # the Kustomization topology (deploy/flux/). When the swap PR removes this KS
+  # file, the parent prunes THIS Kustomization object; with prune:false its
+  # workloads are orphaned (not GC'd) so the bundle-defined child KS adopts them.
+  prune: false
   wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/migrate.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/migrate.yaml
@@ -36,6 +36,10 @@ spec:
   interval: 2m
   retryInterval: 1m
   timeout: 5m
-  prune: true
+  # prune DISABLED ahead of the GitOps topology cutover — the app repo now owns
+  # the Kustomization topology (deploy/flux/). When the swap PR removes this KS
+  # file, the parent prunes THIS Kustomization object; with prune:false its
+  # workloads are orphaned (not GC'd) so the bundle-defined child KS adopts them.
+  prune: false
   # Wait for the Job to complete before dependents (the brain) roll.
   wait: true


### PR DESCRIPTION
Prep (PR 1 of 2) for consolidating the janet GitOps topology into the app bundle. The app repo now owns its Flux Kustomization topology in `deploy/flux/` (freckleapps/janet#100). This PR just disables prune on the three child KSs so the follow-up swap is safe.

## What
`prune: false` on `janet-migrate`, `janet-brain`, `janet-controller` (the child KSs under `apps/janet`). No functional change on its own — they keep reconciling `./migrate` / `./workloads` / `./coding` unchanged.

## Why
The swap PR (2/2) will remove these three KS files and repoint the parent `janet-apps` KS at `oci://…/janet-manifests//flux` (a single bootstrap that applies the bundle-defined child KSs). When the parent stops listing these files it prunes the KS *objects*; with `prune: false` their **workloads are orphaned, not garbage-collected**, so the bundle-defined child KSs (same paths, `janet-brain`→`janet-api` rename) adopt the running resources. Same prune-safe adoption used in the original git→OCI cutover (#2062).

Merge this, let it reconcile (so the controller records `prune: false`), **then** the swap PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low immediate blast radius (no topology change), but it is deliberate Flux ownership/pruning behavior ahead of a two-step cutover where ordering mistakes could affect workload GC during the swap.
> 
> **Overview**
> **Prep step (1 of 2)** for moving janet’s Flux Kustomization topology into the app bundle (`deploy/flux/`). This PR does not repoint sources or remove KS files yet.
> 
> On **`janet-migrate`**, **`janet-brain`**, and **`janet-controller`**, **`prune` changes from `true` to `false`**, with comments documenting the cutover. Reconciliation paths (`./migrate`, `./workloads`, `./coding`) and the rest of each spec stay the same, so day-to-day behavior is unchanged until the swap PR.
> 
> **Why:** When the parent `janet-apps` KS later drops these child KS manifests, Flux will prune the Kustomization *objects*. With **`prune: false`**, their applied workloads are **orphaned rather than deleted**, so bundle-defined child KSs (e.g. `janet-api` replacing `janet-brain`) can adopt existing resources—same pattern as the prior git→OCI cutover.
> 
> Merge and let Flux reconcile so the controller records `prune: false` **before** merging the swap PR (2/2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58dd37c4b632bcfc752a4640b1c6cfd13d9d38b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->