### PR TITLE
fix(inference): headless qwen Service for per-request LB across pods

### DIFF
--- a/kubernetes/apps/inference/models/qwen36-35b-a3b/service.yaml
+++ b/kubernetes/apps/inference/models/qwen36-35b-a3b/service.yaml
@@ -1,13 +1,20 @@
 ---
-# Single ClusterIP fronting both replicas. kube-proxy load-balances across the
-# pods and drops any pod that fails its /health readiness probe, so losing one
-# instance keeps requests flowing. (No BackendTrafficPolicy — see route.yaml for
-# why active health-check / least-request / outlier-eject isn't applied.)
+# Headless (clusterIP: None) so the AI gateway load-balances per REQUEST across
+# both replicas. A ClusterIP resolves to a single VIP, so Envoy's Backend saw
+# ONE endpoint and kube-proxy picked the pod per TCP connection — and because
+# Envoy holds only a handful of long-lived upstream connections for low-
+# concurrency LLM traffic, kube-proxy pinned ~99% of requests onto one pod while
+# the other GPU sat idle (measured over hours via vllm:generation_tokens_total).
+# Headless returns one A record per READY pod, so Envoy's STRICT_DNS cluster
+# creates an endpoint per pod and round-robins across them; the /health readiness
+# probe still drops a sick pod out of DNS. Nothing consumes the VIP (only the EAG
+# Backend FQDN and the pod-level vmservicescrape reference this Service).
 apiVersion: v1
 kind: Service
 metadata:
   name: qwen36-35b-a3b
 spec:
+  clusterIP: None
   selector:
     app.kubernetes.io/name: qwen36-35b-a3b
   ports:

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
@@ -10,10 +10,15 @@
 # gateway-only — each rule rewrites the semantic name to qwen3.6-35b-a3b via
 # modelNameOverride.
 #
-# HA: the Backend resolves to the qwen Service ClusterIP; kube-proxy load-balances
-# across the two pods and drops any pod that fails its /health readiness probe, so
-# losing one instance keeps requests flowing. (Active health-check / least-request
-# / outlier-eject tuning isn't applied: EAG requires AIServiceBackend→Backend, and
+# HA: the qwen Service is HEADLESS, so this FQDN resolves to one A record per
+# ready pod and Envoy's STRICT_DNS cluster load-balances per REQUEST (round-robin)
+# across the pods, dropping any that fail /health. This replaced a ClusterIP,
+# which gave Envoy a single VIP endpoint and let kube-proxy pin ~99% of traffic
+# to one pod (per-connection L4 LB + few long-lived upstream connections). Real
+# per-request LB needs Envoy to see the pod endpoints — EDS via a direct Service
+# backendRef isn't supported until EAG implements envoyproxy/ai-gateway#902, so
+# headless DNS is the mechanism until then. (least-request / active-health /
+# outlier-eject still unavailable: EAG requires AIServiceBackend→Backend, and
 # BackendTrafficPolicy can only target a Gateway/Route — a Gateway-scoped policy
 # would also hit the shared Anthropic backend. Revisit if backend-scoped traffic
 # policy lands.)

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/qwen36-35b-a3b.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/qwen36-35b-a3b.yaml
@@ -30,3 +30,8 @@ spec:
   timeout: 30m
   prune: true
   wait: true
+  # spec.clusterIP is immutable, so converting the Service from ClusterIP to
+  # headless can't be done by a patch — force lets Flux delete+recreate it. Safe
+  # to leave on: it only recreates a resource when an in-place apply hits an
+  # immutable-field conflict (rare), and it self-heals such drift going forward.
+  force: true


### PR DESCRIPTION
## Problem

Requests to the local Qwen model were **~99% pinned to one of the two pods**, leaving the second GPU idle. Measured over hours via `vllm:generation_tokens_total`: ~1845 tokens on one pod vs ~19 on the other (last 6h); ~5.4:1 skew on prompt tokens over 7d.

### Root cause

```
janet → ai-gateway (ClusterIP) → Envoy AI Gateway → Backend qwen36-35b-a3b
                                                       └─ fqdn: qwen36-35b-a3b.inference.svc.cluster.local:8000
```

The `Backend` points at the **Service DNS name**, which for a ClusterIP Service resolves to a single VIP. So Envoy sees **one upstream endpoint** and pod selection falls to **kube-proxy at L4 — per TCP connection**. Envoy holds only a few long-lived upstream connections for low-concurrency LLM traffic, so kube-proxy pins almost everything to one pod. The old comments assumed "kube-proxy load-balances across the pods," which is only true per-connection, not per-request.

## Fix

Make the Service **headless** (`clusterIP: None`). The DNS name then returns one A record per **ready** pod, Envoy's STRICT_DNS cluster creates an endpoint per pod, and it round-robins **per request**. Readiness (`/health`) still gates DNS membership.

- Verified the container's `http` port is `8000`, so Envoy connecting directly to `podIP:8000` (no service-port remap) is correct.
- `clusterIP` is immutable → added `force: true` to the Flux Kustomization so Flux delete+recreates the Service on this transition.

### Why not direct-Service EDS (the idiomatic fix)

EAG **v0.7.0** requires `AIServiceBackend → Backend` and its CRD CEL rule rejects a `kind: Service` backendRef (per envoyproxy/ai-gateway#902, "in the future"). So headless DNS is the mechanism until EAG supports Service EDS.

## Rollout note

On merge, Flux will delete+recreate the Service headless. Pods are untouched; Envoy re-resolves DNS to the same pod IPs within its refresh interval. Expect at most a few seconds of blip during the recreate. **Verify after:** both pods should start taking traffic —
`sum by (pod) (increase(vllm:generation_tokens_total{namespace="inference"}[15m]))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rollout deletes and recreates the Service (short upstream blip) and changes how the AI gateway discovers backends, but does not alter auth, models, or pod specs.
> 
> **Overview**
> Fixes severe traffic skew (~99% to one pod) for the two-replica Qwen vLLM deployment by making **`qwen36-35b-a3b` a headless Service** (`clusterIP: None`) instead of a ClusterIP VIP.
> 
> With ClusterIP, Envoy AI Gateway’s FQDN backend saw a single endpoint and kube-proxy balanced **per TCP connection**, which pinned almost all LLM requests on one GPU. Headless DNS exposes one A record per ready pod so Envoy’s STRICT_DNS cluster can **round-robin per request**; readiness on `/health` still controls DNS membership. Inline docs in the Service and fairy `Backend` route are updated to describe this mechanism and note EDS via Service backendRef is blocked until EAG #902.
> 
> Because **`spec.clusterIP` is immutable**, the fairy Flux **Kustomization** gains **`force: true`** so Flux can delete and recreate the Service on apply (pods unchanged; brief DNS blip possible on rollout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0daca32eba388974137bf881cc919470df7465c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->