### PR TITLE
feat(inference): add MiniMax-M2.7-NVFP4 2-node vLLM, scale Qwen to 1

### DIFF
--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/cnp.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/cnp.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/cilium.io/ciliumnetworkpolicy_v2.json
+# Egress lockdown is what makes the secure tiers honest: the model can't phone
+# home. Weights are pre-staged on CephFS (storage path is not pod egress), so
+# DNS is the only outbound the pod gets — plus intra-group traffic so the
+# leader/worker ranks can bootstrap torch.distributed (NCCL's collective itself
+# rides the ConnectX-7 RDMA fabric, which is a separate interface Cilium does
+# not police; only the master :29500 rendezvous crosses the pod network).
+# Ingress only from the AI gateway and the metrics scraper — plus the sibling
+# rank on the pod network.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: minimax-m27-nvfp4
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: minimax-m27-nvfp4
+  ingress:
+    # Sibling rank (leader<->worker) — distributed bootstrap on the pod network.
+    # All ports: torch/NCCL negotiate side-channel ports dynamically.
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: minimax-m27-nvfp4
+    # The in-cluster AI gateway (envoy-clusterip "ai" Gateway) — the API client
+    # once routes are wired.
+    - fromEndpoints:
+        - matchLabels:
+            gateway.envoyproxy.io/owning-gateway-name: ai
+            gateway.envoyproxy.io/owning-gateway-namespace: inference
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # vmagent scraping /metrics.
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: vmagent
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+  egress:
+    # Sibling rank (leader<->worker) — distributed bootstrap on the pod network.
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: minimax-m27-nvfp4
+    # DNS only. Declaring any egress rule flips Cilium to default-deny egress
+    # for these pods — no world, no on-site networks, no HF.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/kustomization.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cnp.yaml
+  - ./leaderworkerset.yaml
+  - ./service.yaml
+  - ./vmservicescrape.yaml

--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/leaderworkerset.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/leaderworkerset.yaml
@@ -1,0 +1,200 @@
+---
+# MiniMax-M2.7 (NVFP4) served by vLLM across 2 DGX nodes as a single
+# tensor-parallel replica (tp=2, one GB10 per rank). Adapted from the
+# vLLM recipe at github.com/eugr/spark-vllm-docker (recipes/minimax-m2.7-awq),
+# with three deliberate deviations from that recipe:
+#   1. Model swapped to nvidia/MiniMax-M2.7-NVFP4 (230B MoE, 10B active, NVFP4)
+#      — vLLM auto-detects the modelopt/NVFP4 quantization from the checkpoint,
+#      so no explicit --quantization is needed.
+#   2. Multi-node launch uses vLLM's NATIVE distributed backend over a
+#      LeaderWorkerSet (--nnodes/--node-rank/--master-addr), not the recipe's
+#      Ray backend — this matches the proven gpt-oss 2-node pattern here and
+#      avoids standing up a separate Ray cluster.
+#   3. Runs on the official aarch64 vLLM image (the recipe's eugr/spark-vllm is
+#      x86-64 only and won't run on the GB10 arm64 nodes). Weights are
+#      pre-staged on CephFS (see the download job), so it serves fully offline
+#      (HF_HUB_OFFLINE=1) with no HF secret — egress is locked in cnp.yaml.
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: minimax-m27-nvfp4
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    restartPolicy: RecreateGroupOnPodRestart
+    leaderTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/name: minimax-m27-nvfp4
+          app.kubernetes.io/component: leader
+      spec:
+        runtimeClassName: nvidia
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        resourceClaims:
+          - name: gpu-rdma
+            resourceClaimTemplateName: gpu-rdma
+        containers:
+          - name: vllm
+            # Official aarch64 vLLM (same image the Qwen deploy runs on these
+            # GB10 nodes). CUDA-13 / Ubuntu 24.04.
+            image: mirror.gcr.io/vllm/vllm-openai:v0.24.0-aarch64-ubuntu2404
+            command:
+              - bash
+              - -c
+              - |
+                vllm serve nvidia/MiniMax-M2.7-NVFP4 \
+                  --served-model-name nvidia/MiniMax-M2.7-NVFP4 minimax-m2.7 \
+                  --trust-remote-code \
+                  --tensor-parallel-size 2 \
+                  --gpu-memory-utilization 0.8 \
+                  --max-model-len 196608 \
+                  --load-format fastsafetensors \
+                  --enable-auto-tool-choice \
+                  --tool-call-parser minimax_m2 \
+                  --reasoning-parser minimax_m2_append_think \
+                  --nnodes 2 \
+                  --node-rank 0 \
+                  --master-addr $${LWS_LEADER_ADDRESS} \
+                  --master-port 29500 \
+                  --host 0.0.0.0 \
+                  --port 8000
+            env:
+              - name: HF_HOME
+                value: /models
+              # Weights pre-staged on CephFS (/models/hub); never reach HF at
+              # serve time (egress is locked — see cnp.yaml).
+              - name: HF_HUB_OFFLINE
+                value: "1"
+              - name: DO_NOT_TRACK
+                value: "1"
+              - name: PYTORCH_CUDA_ALLOC_CONF
+                value: expandable_segments:True
+              # NCCL: use RDMA over the ConnectX-7 fabric (dranet gpu-rdma claim).
+              - name: NCCL_IB_HCA
+                value: mlx5
+              - name: NCCL_NET_GDR_LEVEL
+                value: "2"
+            ports:
+              - containerPort: 8000
+                name: http
+              - containerPort: 29500
+                name: dist-coord
+            startupProbe:
+              httpGet:
+                path: /health
+                port: http
+              initialDelaySeconds: 60
+              periodSeconds: 10
+              timeoutSeconds: 5
+              # Long — first load is a 116GB NVFP4 checkpoint from CephFS across
+              # 2 nodes + torch.compile + cudagraph capture.
+              failureThreshold: 360
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: http
+              periodSeconds: 30
+              timeoutSeconds: 5
+              failureThreshold: 3
+            readinessProbe:
+              httpGet:
+                path: /health
+                port: http
+              periodSeconds: 30
+              timeoutSeconds: 5
+              failureThreshold: 3
+            securityContext:
+              capabilities:
+                add:
+                  - IPC_LOCK
+            resources:
+              claims:
+                - name: gpu-rdma
+            volumeMounts:
+              - name: models
+                mountPath: /models
+              - name: shm
+                mountPath: /dev/shm
+        volumes:
+          - name: models
+            persistentVolumeClaim:
+              claimName: models
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 16Gi
+    workerTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/name: minimax-m27-nvfp4
+          app.kubernetes.io/component: worker
+      spec:
+        runtimeClassName: nvidia
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        resourceClaims:
+          - name: gpu-rdma
+            resourceClaimTemplateName: gpu-rdma
+        containers:
+          - name: vllm
+            image: mirror.gcr.io/vllm/vllm-openai:v0.24.0-aarch64-ubuntu2404
+            command:
+              - bash
+              - -c
+              - |
+                vllm serve nvidia/MiniMax-M2.7-NVFP4 \
+                  --served-model-name nvidia/MiniMax-M2.7-NVFP4 minimax-m2.7 \
+                  --trust-remote-code \
+                  --tensor-parallel-size 2 \
+                  --gpu-memory-utilization 0.8 \
+                  --max-model-len 196608 \
+                  --load-format fastsafetensors \
+                  --enable-auto-tool-choice \
+                  --tool-call-parser minimax_m2 \
+                  --reasoning-parser minimax_m2_append_think \
+                  --nnodes 2 \
+                  --node-rank 1 \
+                  --master-addr $${LWS_LEADER_ADDRESS} \
+                  --master-port 29500 \
+                  --headless \
+                  --host 0.0.0.0 \
+                  --port 8000
+            env:
+              - name: HF_HOME
+                value: /models
+              - name: HF_HUB_OFFLINE
+                value: "1"
+              - name: DO_NOT_TRACK
+                value: "1"
+              - name: PYTORCH_CUDA_ALLOC_CONF
+                value: expandable_segments:True
+              - name: NCCL_IB_HCA
+                value: mlx5
+              - name: NCCL_NET_GDR_LEVEL
+                value: "2"
+            securityContext:
+              capabilities:
+                add:
+                  - IPC_LOCK
+            resources:
+              claims:
+                - name: gpu-rdma
+            volumeMounts:
+              - name: models
+                mountPath: /models
+              - name: shm
+                mountPath: /dev/shm
+        volumes:
+          - name: models
+            persistentVolumeClaim:
+              claimName: models
+          - name: shm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 16Gi

--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/service.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/service.yaml
@@ -1,0 +1,21 @@
+---
+# Headless (clusterIP: None) so a per-request load-balancer (the AI gateway,
+# once wired) sees an endpoint per READY pod rather than a single VIP. Only the
+# leader serves the OpenAI API — the worker is headless (--headless) and never
+# becomes Ready on :8000 — so in practice this returns the leader's address.
+# publishNotReadyAddresses keeps the leader discoverable during the long model
+# load so clients/scrapers can attach before it flips Ready.
+apiVersion: v1
+kind: Service
+metadata:
+  name: minimax-m27-nvfp4
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: minimax-m27-nvfp4
+    app.kubernetes.io/component: leader
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/vmservicescrape.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/vmservicescrape.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: minimax-m27-nvfp4
+spec:
+  endpoints:
+    - interval: 30s
+      port: http
+      path: /metrics
+      relabelConfigs:
+        - targetLabel: vllm_deployment
+          replacement: minimax-m27-nvfp4
+  namespaceSelector:
+    matchNames:
+      - inference
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minimax-m27-nvfp4

--- a/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
+++ b/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
@@ -1,18 +1,18 @@
 ---
-# Qwen3.6-35B-A3B-FP8 served by vLLM, single-node (tp=1) per GB10. Two replicas
-# spread one-per-DGX-node (podAntiAffinity) form the HA pair; the in-cluster AI
-# gateway load-balances + health-checks across them. RollingUpdate surges a
-# replacement pod when a DGX node is free, but falls back to taking one
-# replica down first (briefly serving from just the other) when all DGX
-# nodes are occupied (e.g. a 3rd local model on dgx03) — the strict
-# one-pod-per-node podAntiAffinity means a surge pod can't schedule without
-# a free node, so this keeps the rollout from ever getting stuck.
+# Qwen3.6-35B-A3B-FP8 served by vLLM, single-node (tp=1) per GB10. Scaled to a
+# single replica: two of the three DGX nodes are now claimed by the 2-node
+# minimax-m27-nvfp4 LeaderWorkerSet, leaving exactly one node for Qwen. No
+# longer an HA pair — a node loss takes Qwen down until it reschedules. The
+# one-pod-per-node podAntiAffinity is retained so that if this is scaled back
+# up (once GPUs free), replicas still spread across distinct DGX nodes.
+# RollingUpdate keeps maxSurge/maxUnavailable so a scale-up rollout never wedges
+# when all DGX nodes are occupied.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qwen36-35b-a3b
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml
@@ -44,6 +44,33 @@ spec:
     kind: Backend
     name: qwen36-35b-a3b
 ---
+# MiniMax-M2.7 (NVFP4), served by the 2-node vLLM LeaderWorkerSet. Only the
+# leader exposes the OpenAI API, so the minimax-m27-nvfp4 Service selects the
+# leader pod only — this Backend resolves that single ready A record (no
+# per-request LB to do; it's one serving replica across two tensor-parallel
+# ranks, unlike qwen's headless multi-replica pool).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: minimax-m27-nvfp4
+spec:
+  endpoints:
+    - fqdn:
+        hostname: minimax-m27-nvfp4.inference.svc.cluster.local
+        port: 8000
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: AIServiceBackend
+metadata:
+  name: local-minimax-m27-nvfp4
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    group: gateway.envoyproxy.io
+    kind: Backend
+    name: minimax-m27-nvfp4
+---
 apiVersion: aigateway.envoyproxy.io/v1beta1
 kind: AIGatewayRoute
 metadata:
@@ -73,5 +100,18 @@ spec:
       # generations mid-stream. 30m is a runaway backstop a real turn never
       # reaches — a genuinely stalled stream is reaped far sooner by the
       # gateway-wide streamIdleTimeout (see ai-buffer-limit ClientTrafficPolicy).
+      timeouts:
+        request: 1800s
+    # MiniMax-M2.7 (NVFP4). Clients send model=nvidia/MiniMax-M2.7-NVFP4 (the
+    # canonical served name, also what surfaces in GET /v1/models); the override
+    # sends the shorter semantic id, also in the deploy's --served-model-name.
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: nvidia/MiniMax-M2.7-NVFP4
+      backendRefs:
+        - name: local-minimax-m27-nvfp4
+          modelNameOverride: minimax-m2.7
       timeouts:
         request: 1800s

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./external-secrets.yaml
   - ./huggingface.yaml
   - ./leader-worker-set.yaml
+  - ./minimax-m27-nvfp4.yaml
   - ./models-pvc.yaml
   - ./qwen36-35b-a3b.yaml
   - ./resource-claims.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/minimax-m27-nvfp4.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/minimax-m27-nvfp4.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app minimax-m27-nvfp4
+  namespace: &namespace inference
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # No huggingface dep: serves pre-staged weights with HF_HUB_OFFLINE=1 and
+    # never reads the HF secret. Real deps are the LWS controller, the DRA
+    # claim templates, and the GPU/DRA driver.
+    - name: leader-worker-set
+      namespace: inference
+    - name: resource-claims
+      namespace: inference
+    - name: nvidia-gpu-operator
+      namespace: gpu-operator
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/inference/models/minimax-m27-nvfp4
+  interval: 2m
+  retryInterval: 1m
+  timeout: 30m
+  prune: true
+  wait: true


### PR DESCRIPTION
## Summary

Deploys **`nvidia/MiniMax-M2.7-NVFP4`** (230B MoE, 10B active) as a **2-node tensor-parallel (tp=2) vLLM LeaderWorkerSet** across the GB10 DGX nodes, and scales the **Qwen HA pair down to a single replica** to free the two nodes it needs.

**Node math:** 3 DGX nodes total → `qwen(1)` + `minimax(2)` = 3, fits exactly.

## What's here

- **`apps/inference/models/minimax-m27-nvfp4/`** — LeaderWorkerSet (size 2), headless Service (leader-only), egress-locked CNP, VMServiceScrape, kustomization.
- **`apps/inference/models/qwen36-35b-a3b/deployment.yaml`** — `replicas: 2 → 1` (+ comment update; antiaffinity/RollingUpdate retained for a future scale-up).
- **`clusters/fairy-k8s01/apps/inference/minimax-m27-nvfp4.yaml`** — Flux pointer + wired into the inference kustomization.
- **`clusters/fairy-k8s01/apps/inference/ai-routes/route.yaml`** — `Backend` + `AIServiceBackend` + route rule so clients reach it as `model=nvidia/MiniMax-M2.7-NVFP4`.

## Adapted from the `eugr/spark-vllm-docker` `minimax-m2.7-awq` recipe

Model swapped to the nvidia NVFP4 checkpoint. Three infra-forced deviations from the recipe:

| Recipe | Here | Why |
|---|---|---|
| `eugr/spark-vllm` (x86-64) | `vllm/vllm-openai:v0.24.0-aarch64` | Recipe image won't run on the arm64 GB10 nodes (same image Qwen uses) |
| `--distributed-executor-backend ray` | native LWS `--nnodes/--node-rank/--master-addr` | Matches the proven gpt-oss 2-node pattern; no Ray cluster to stand up |
| `--reasoning-parser minimax_m2` | `minimax_m2_append_think` | nvidia NVFP4 model card recommendation |

Serves **offline from CephFS-staged weights** (`HF_HUB_OFFLINE=1`, no HF secret). vLLM auto-detects the NVFP4/modelopt quantization.

## Network policy

Egress: DNS + sibling rank only (the model can't phone home). Ingress: AI gateway (`:8000`), vmagent (`:8000`), and the sibling rank (all ports, for the torch/NCCL rendezvous on the pod network — the NCCL collective itself rides the ConnectX-7 RDMA fabric, which Cilium doesn't police).

## Notes / caveats

- Weights are being pre-staged by a `download-nvidia-minimax-m2.7-nvfp4` job. Until it completes, the LWS pods crashloop on the missing checkpoint (harmless) and the route returns 503 — same as any model-load window.
- `--load-format fastsafetensors` is included on the assumption it's present in the official aarch64 image; easy to drop if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reallocates scarce GPU capacity and removes Qwen HA; new multi-node inference workload with long startup and dependency on pre-staged weights.
> 
> **Overview**
> Adds **MiniMax-M2.7-NVFP4** as a new local model: a 2-node **LeaderWorkerSet** running vLLM with tensor parallel size 2, offline weights from CephFS (`HF_HUB_OFFLINE=1`), RDMA via `gpu-rdma` claims, plus a leader-only headless Service, egress-locked **CiliumNetworkPolicy**, **VMServiceScrape**, and a Flux **Kustomization** on `fairy-k8s01`.
> 
> **Qwen** is scaled from **2 → 1** replica so two DGX nodes can host MiniMax while one remains for Qwen—no longer an HA pair until scaled back up.
> 
> The in-cluster **AI gateway** gains a `Backend` / `AIServiceBackend` and an `AIGatewayRoute` rule for `model=nvidia/MiniMax-M2.7-NVFP4` (30m request timeout, `minimax-m2.7` override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8893073c43986ba3707e99470ba9c078350e6fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->