### PR TITLE
feat(inference): cache MiniMax weights to node-local NVMe + revert reasoning parser

### DIFF
--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/leaderworkerset.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/leaderworkerset.yaml
@@ -11,12 +11,15 @@
 #      LeaderWorkerSet (--nnodes/--node-rank/--master-addr), not the recipe's
 #      Ray backend — this matches the proven gpt-oss 2-node pattern here and
 #      avoids standing up a separate Ray cluster.
-# --load-format instanttensor is what keeps the two ranks in sync during the
-# weight load: the stock upstream vLLM image lacks the InstantTensor library, so
-# it fell back to fastsafetensors, whose bursty prefetch let the ranks drift on
-# our slow CephFS path until NCCL's 600s collective watchdog killed the group.
-# Weights are pre-staged on CephFS (see the download job), so it serves fully
-# offline (HF_HUB_OFFLINE=1) with no HF secret — egress is locked in cnp.yaml.
+# --load-format instanttensor keeps the two ranks in sync during the weight load
+# (the stock upstream vLLM image lacks the InstantTensor library and fell back to
+# fastsafetensors, whose bursty prefetch let the ranks drift on our slow CephFS
+# path until NCCL's 600s collective watchdog killed the group). The rclone init
+# container below is the stronger mitigation: it caches the checkpoint to
+# node-local NVMe first, so vLLM loads from fast local disk and the slow CephFS
+# read happens once per node in a plain copy — not on every load, and not coupled
+# to any NCCL collective. Weights are pre-staged on CephFS by the download job;
+# served fully offline (HF_HUB_OFFLINE=1), no HF secret — egress locked in cnp.yaml.
 apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
@@ -40,6 +43,34 @@ spec:
         resourceClaims:
           - name: gpu-rdma
             resourceClaimTemplateName: gpu-rdma
+        initContainers:
+          # Cache the checkpoint from CephFS to node-local NVMe before vLLM starts.
+          # -L dereferences the HF-cache symlinks so the local copy is
+          # self-contained; scoped to the minimax dir (the `models` PVC is shared
+          # with qwen + gpt-oss) and excludes blobs/ since the deref'd snapshot
+          # already holds the data (avoids a 2x copy). hostPath persists across
+          # RecreateGroupOnPodRestart, so restarts re-sync incrementally (fast).
+          - name: cache-models
+            image: mirror.gcr.io/rclone/rclone:1.73.4
+            command:
+              - rclone
+              - sync
+              - /ceph-models/hub/models--nvidia--MiniMax-M2.7-NVFP4/
+              - /models/hub/models--nvidia--MiniMax-M2.7-NVFP4/
+              - --copy-links
+              - --exclude
+              - blobs/**
+              - --transfers
+              - "8"
+              - --checkers
+              - "16"
+              - --progress
+            volumeMounts:
+              - name: ceph-models
+                mountPath: /ceph-models
+                readOnly: true
+              - name: local-models
+                mountPath: /models
         containers:
           - name: vllm
             # eugr spark-vllm (arm64, built for GB10 DGX Spark). Ships
@@ -58,7 +89,7 @@ spec:
                   --load-format instanttensor \
                   --enable-auto-tool-choice \
                   --tool-call-parser minimax_m2 \
-                  --reasoning-parser minimax_m2_append_think \
+                  --reasoning-parser minimax_m2 \
                   --nnodes 2 \
                   --node-rank 0 \
                   --master-addr $${LWS_LEADER_ADDRESS} \
@@ -98,8 +129,9 @@ spec:
               initialDelaySeconds: 60
               periodSeconds: 10
               timeoutSeconds: 5
-              # Long — first load is a 116GB NVFP4 checkpoint from CephFS across
-              # 2 nodes + torch.compile + cudagraph capture.
+              # Long — covers the vLLM load from node-local NVMe (the CephFS→local
+              # rclone sync runs first as an initContainer) + torch.compile +
+              # cudagraph capture. The startup-probe clock starts after init.
               failureThreshold: 360
             livenessProbe:
               httpGet:
@@ -123,14 +155,21 @@ spec:
               claims:
                 - name: gpu-rdma
             volumeMounts:
-              - name: models
+              - name: local-models
                 mountPath: /models
               - name: shm
                 mountPath: /dev/shm
         volumes:
-          - name: models
+          # Source: shared models PVC on CephFS (read-only; init copies out of it).
+          - name: ceph-models
             persistentVolumeClaim:
               claimName: models
+          # Dest: node-local NVMe cache. hostPath persists across pod restarts so
+          # the CephFS sync is a one-time-per-node cost; vLLM reads weights here.
+          - name: local-models
+            hostPath:
+              path: /var/local/inference-models
+              type: DirectoryOrCreate
           - name: shm
             emptyDir:
               medium: Memory
@@ -149,6 +188,34 @@ spec:
         resourceClaims:
           - name: gpu-rdma
             resourceClaimTemplateName: gpu-rdma
+        initContainers:
+          # Cache the checkpoint from CephFS to node-local NVMe before vLLM starts.
+          # -L dereferences the HF-cache symlinks so the local copy is
+          # self-contained; scoped to the minimax dir (the `models` PVC is shared
+          # with qwen + gpt-oss) and excludes blobs/ since the deref'd snapshot
+          # already holds the data (avoids a 2x copy). hostPath persists across
+          # RecreateGroupOnPodRestart, so restarts re-sync incrementally (fast).
+          - name: cache-models
+            image: mirror.gcr.io/rclone/rclone:1.73.4
+            command:
+              - rclone
+              - sync
+              - /ceph-models/hub/models--nvidia--MiniMax-M2.7-NVFP4/
+              - /models/hub/models--nvidia--MiniMax-M2.7-NVFP4/
+              - --copy-links
+              - --exclude
+              - blobs/**
+              - --transfers
+              - "8"
+              - --checkers
+              - "16"
+              - --progress
+            volumeMounts:
+              - name: ceph-models
+                mountPath: /ceph-models
+                readOnly: true
+              - name: local-models
+                mountPath: /models
         containers:
           - name: vllm
             # eugr spark-vllm (arm64) — same image as the leader. Digest-pinned.
@@ -166,7 +233,7 @@ spec:
                   --load-format instanttensor \
                   --enable-auto-tool-choice \
                   --tool-call-parser minimax_m2 \
-                  --reasoning-parser minimax_m2_append_think \
+                  --reasoning-parser minimax_m2 \
                   --nnodes 2 \
                   --node-rank 1 \
                   --master-addr $${LWS_LEADER_ADDRESS} \
@@ -200,14 +267,21 @@ spec:
               claims:
                 - name: gpu-rdma
             volumeMounts:
-              - name: models
+              - name: local-models
                 mountPath: /models
               - name: shm
                 mountPath: /dev/shm
         volumes:
-          - name: models
+          # Source: shared models PVC on CephFS (read-only; init copies out of it).
+          - name: ceph-models
             persistentVolumeClaim:
               claimName: models
+          # Dest: node-local NVMe cache. hostPath persists across pod restarts so
+          # the CephFS sync is a one-time-per-node cost; vLLM reads weights here.
+          - name: local-models
+            hostPath:
+              path: /var/local/inference-models
+              type: DirectoryOrCreate
           - name: shm
             emptyDir:
               medium: Memory

--- a/kubernetes/apps/inference/models/minimax-m27-nvfp4/leaderworkerset.yaml
+++ b/kubernetes/apps/inference/models/minimax-m27-nvfp4/leaderworkerset.yaml
@@ -51,7 +51,7 @@ spec:
           # already holds the data (avoids a 2x copy). hostPath persists across
           # RecreateGroupOnPodRestart, so restarts re-sync incrementally (fast).
           - name: cache-models
-            image: mirror.gcr.io/rclone/rclone:1.73.4
+            image: mirror.gcr.io/rclone/rclone:1.73.4@sha256:654f6517c7aaec7e377690b2caf7c272dbe5f3b8200afbc14a00df6b4a9aa6ef
             command:
               - rclone
               - sync
@@ -164,6 +164,7 @@ spec:
           - name: ceph-models
             persistentVolumeClaim:
               claimName: models
+              readOnly: true
           # Dest: node-local NVMe cache. hostPath persists across pod restarts so
           # the CephFS sync is a one-time-per-node cost; vLLM reads weights here.
           - name: local-models
@@ -196,7 +197,7 @@ spec:
           # already holds the data (avoids a 2x copy). hostPath persists across
           # RecreateGroupOnPodRestart, so restarts re-sync incrementally (fast).
           - name: cache-models
-            image: mirror.gcr.io/rclone/rclone:1.73.4
+            image: mirror.gcr.io/rclone/rclone:1.73.4@sha256:654f6517c7aaec7e377690b2caf7c272dbe5f3b8200afbc14a00df6b4a9aa6ef
             command:
               - rclone
               - sync
@@ -276,6 +277,7 @@ spec:
           - name: ceph-models
             persistentVolumeClaim:
               claimName: models
+              readOnly: true
           # Dest: node-local NVMe cache. hostPath persists across pod restarts so
           # the CephFS sync is a one-time-per-node cost; vLLM reads weights here.
           - name: local-models


### PR DESCRIPTION
## Summary

Two changes to the MiniMax-M2.7-NVFP4 2-node LeaderWorkerSet:

### 1. rclone init container → node-local NVMe cache
Restores the local-cache pattern from `52d911f5`. A `cache-models` init container `rclone sync`s the checkpoint from the shared CephFS `models` PVC to a node-local NVMe **hostPath** (`/var/local/inference-models`) before vLLM starts. vLLM then loads from **local disk**, not CephFS.

**Why:** the slow, Firewalla-routed ~1 G CephFS path is what made loads take ~11 min and (on the stock image) desync the ranks. Moving the copy into an init container means that slow read happens **once per node as a plain copy** — not on every load, and not coupled to the NCCL collectives a slow load stalls past the 600 s watchdog. `hostPath` persists across `RecreateGroupOnPodRestart`, so **restarts re-sync incrementally and load fast** from local NVMe.

Adaptations vs the old gpt-oss pattern (the PVC is now shared by qwen + gpt-oss + minimax, and weights are HF-cache symlinks):
- **Scoped** to `models--nvidia--MiniMax-M2.7-NVFP4/` only (not the whole `/hub`).
- **`--copy-links`** to dereference the `snapshots/*/… → ../../blobs/…` symlinks so the local copy is self-contained.
- **`--exclude blobs/**`** so we don't copy the data twice (the deref'd snapshot already holds it) — 131 G, not 262 G. DGX nodes have 3.6 T free.

### 2. Revert reasoning parser `minimax_m2_append_think` → `minimax_m2`
Splits reasoning into `reasoning_content` (clean `content`) instead of leaving `<think>…</think>` inline. Per the decision to handle it infra-side rather than stripping in Janet.

## ⚠️ Apply impact
Merging recreates the LWS group (volume restructure), so the **first** cycle runs the ~131 G CephFS→local sync (~15 min) + reload — **minimax is down ~18 min once**. Subsequent restarts are fast (incremental sync + local load). Fits inside the KS 30 m timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Volume restructure recreates the LWS group (planned ~18 min downtime on first deploy) and changes API response shape via the reasoning parser revert; operational risk is moderate, not security-critical.
> 
> **Overview**
> Adds a **`cache-models` rclone init container** on both leader and worker pods so the MiniMax checkpoint is synced from the shared CephFS `models` PVC to **node-local NVMe** (`hostPath` `/var/local/inference-models`) before vLLM starts. vLLM now mounts **`local-models`** instead of reading weights directly from CephFS, with the PVC mounted read-only as **`ceph-models`** for the init copy only. The sync is scoped to `models--nvidia--MiniMax-M2.7-NVFP4/`, uses **`--copy-links`** and **`--exclude blobs/**`** to avoid duplicating HF blob data.
> 
> **`--reasoning-parser`** is reverted from `minimax_m2_append_think` to **`minimax_m2`**, so reasoning is exposed as `reasoning_content` rather than inline `<think>` tags. Comments and startup-probe notes are updated to reflect init-then-local load behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d50b7e97eaa1eda5b0bb49d874fca6c82839416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->