### PR TITLE
Add Nautobot DCIM deployment (CNPG + Dragonfly + Freckle ID SSO)

### DIFF
--- a/kubernetes/apps/nautobot/app/externalsecret.yaml
+++ b/kubernetes/apps/nautobot/app/externalsecret.yaml
@@ -1,0 +1,36 @@
+---
+# All non-DB/non-broker app secrets in one k8s Secret, projected from GSM
+# (tofu-managed in the private infra repo). The HelmRelease points its
+# django/superUser existingSecret fields and the OIDC extraEnvVars at the
+# keys below.
+#   secret-key         Django SECRET_KEY          (hand-created random)
+#   superuser-password bootstrap admin password   (hand-created random)
+#   superuser-apitoken bootstrap admin API token   (hand-created random)
+#   client-id          Freckle ID OIDC client id   } extracted from the
+#   client-secret      Freckle ID OIDC client secret } tofu-managed oidc blob
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nautobot-secrets
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    creationPolicy: Owner
+  data:
+    - secretKey: secret-key
+      remoteRef:
+        key: ${CLUSTER_NAME}-nautobot-secret-key
+    - secretKey: superuser-password
+      remoteRef:
+        key: ${CLUSTER_NAME}-nautobot-superuser-password
+    - secretKey: superuser-apitoken
+      remoteRef:
+        key: ${CLUSTER_NAME}-nautobot-superuser-apitoken
+  # OIDC client-id/client-secret arrive as a single JSON secret created by
+  # tofu (pocket-id client -> GSM); extract lands both as their own keys.
+  dataFrom:
+    - extract:
+        key: ${CLUSTER_NAME}-nautobot-oidc

--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -1,0 +1,128 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nautobot
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: nautobot
+    namespace: nautobot
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    # Fixed resource names so the HTTPRoute backend and in-cluster DNS are
+    # predictable (web Service becomes `nautobot-default`).
+    fullnameOverride: nautobot
+
+    # Bundled datastores off — we bring our own CNPG Postgres and Dragonfly.
+    postgresql:
+      enabled: false
+    redis:
+      enabled: false
+
+    nautobot:
+      # Chart 3.1.2's appVersion pins the image to 3.0 — override to the latest
+      # Nautobot 3.1.8, pulled from GHCR and pinned by digest.
+      image:
+        registry: ghcr.io
+        repository: nautobot/nautobot
+        tag: "3.1.8@sha256:a8f89c28c6d4585c294d690e3bf4c4e2543d47cf81fd07bf02b2f4e73e959d95"
+
+      # Single web replica for a homelab DCIM; Celery worker + beat run as
+      # their own deployments (chart defaults). Uploaded media (device-type
+      # images, attachments) lives on a shared ceph-filesystem RWX PVC so it
+      # survives restarts and stays consistent if the web tier scales out.
+      # Static files are collected at container start (ephemeral); Git
+      # datasource repos use the chart's default emptyDir and re-sync from
+      # remote. Everything else is in Postgres.
+      replicaCount: 1
+      persistenceMediaFiles:
+        enabled: true
+        storageClassName: ceph-filesystem
+        accessMode: ReadWriteMany
+        size: 5Gi
+      # Space-separated string (NAUTOBOT_ALLOWED_HOSTS). Left as "*" — the only
+      # ingress path is the private tailnet gateway, and scoping it risks
+      # rejecting the chart's in-pod health probes.
+      allowedHosts: "*"
+
+      db:
+        engine: django.db.backends.postgresql
+        # CNPG's read-write Service for the primary.
+        host: nautobot-db-rw.nautobot.svc
+        port: 5432
+        name: nautobot
+        existingSecret: nautobot-db-app-role
+        existingSecretUsernameKey: username
+        existingSecretPasswordKey: password
+
+      redis:
+        host: nautobot-queue.nautobot.svc
+        port: 6379
+        ssl: false
+        existingSecret: nautobot-queue-secrets
+        existingSecretPasswordKey: password
+
+      django:
+        existingSecret: nautobot-secrets
+        existingSecretSecretKeyKey: secret-key
+
+      superUser:
+        enabled: true
+        username: admin
+        email: nicole@freckle.family
+        existingSecret: nautobot-secrets
+        existingSecretPasswordKey: superuser-password
+        existingSecretApiTokenKey: superuser-apitoken
+
+      # nautobot.metrics (NAUTOBOT_METRICS_ENABLED) defaults to true — the
+      # Prometheus endpoint is already exposed; no override needed.
+
+      # OIDC client credentials for the generic python-social-auth backend.
+      # Read by the supplemental config below via os.environ.
+      extraEnvVars:
+        - name: NAUTOBOT_OIDC_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: nautobot-secrets
+              key: client-id
+        - name: NAUTOBOT_OIDC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: nautobot-secrets
+              key: client-secret
+
+      # Supplemental nautobot_config.py appended on top of Nautobot core
+      # settings (which already build DATABASES/CACHES/etc. from the NAUTOBOT_*
+      # env vars the chart injects from the values above). Wires SSO to Freckle
+      # ID (pocket-id) using the generic OIDC backend (backend name "oidc" ->
+      # SOCIAL_AUTH_OIDC_* settings). New OIDC users are auto-created and land
+      # in the "sso" group; grant permissions to that group in Nautobot.
+      config: |
+        import os
+
+        AUTHENTICATION_BACKENDS = [
+            "social_core.backends.open_id_connect.OpenIdConnectAuth",
+            "nautobot.core.authentication.ObjectPermissionBackend",
+        ]
+
+        SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = "https://freckle.id"
+        SOCIAL_AUTH_OIDC_KEY = os.environ.get("NAUTOBOT_OIDC_CLIENT_ID", "")
+        SOCIAL_AUTH_OIDC_SECRET = os.environ.get("NAUTOBOT_OIDC_CLIENT_SECRET", "")
+        # Store social-auth extra_data as a real JSONField (Postgres).
+        SOCIAL_AUTH_JSONFIELD_ENABLED = True
+
+        # Auto-provision SSO users into a default group so they can log in
+        # before an admin assigns object permissions.
+        EXTERNAL_AUTH_DEFAULT_GROUPS = ["sso"]

--- a/kubernetes/apps/nautobot/app/httproute.yaml
+++ b/kubernetes/apps/nautobot/app/httproute.yaml
@@ -1,0 +1,18 @@
+---
+# Front door on the tailnet gateway. The chart's web Service is
+# `nautobot-default` (fullnameOverride: nautobot) on port 80.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nautobot
+spec:
+  hostnames:
+    - nautobot.${CLUSTER_DOMAIN}
+  parentRefs:
+    - name: tailnet
+      namespace: gateway-system
+  rules:
+    - backendRefs:
+        - kind: Service
+          name: nautobot-default
+          port: 80

--- a/kubernetes/apps/nautobot/app/kustomization.yaml
+++ b/kubernetes/apps/nautobot/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/nautobot/app/ocirepository.yaml
+++ b/kubernetes/apps/nautobot/app/ocirepository.yaml
@@ -1,0 +1,17 @@
+---
+# Nautobot Helm chart from GHCR (OCI). Tag is `v`-prefixed; digest pins it
+# immutably. Bump both together on chart upgrades.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nautobot
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v3.1.2
+    digest: sha256:53e2ad93c89a25ae49dc6bc982b9790a016aab8c504114f694f0e36c001e3142
+  url: oci://ghcr.io/nautobot/helm-charts/nautobot

--- a/kubernetes/apps/nautobot/db/app-role-externalsecret.yaml
+++ b/kubernetes/apps/nautobot/db/app-role-externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# Login role for the Nautobot application. CNPG's managed.roles consumes
+# this (username/password) to create/reconcile the `nautobot` role; the
+# Nautobot HelmRelease reuses the SAME secret as its db existingSecret, so
+# the app and the role can never drift. Password lives in GSM (tofu-managed).
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nautobot-db-app-role
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: "nautobot"
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ${CLUSTER_NAME}-nautobot-db-app-password

--- a/kubernetes/apps/nautobot/db/bucket.yaml
+++ b/kubernetes/apps/nautobot/db/bucket.yaml
@@ -1,0 +1,12 @@
+---
+# Rook OBC: provisions `nautobot-db-backups` in Ceph RGW and creates a
+# Secret + ConfigMap of the same name as this OBC. The Secret contains
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY scoped to this bucket — the
+# barmancloud ObjectStore consumes that secret directly.
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: nautobot-db-bucket
+spec:
+  bucketName: nautobot-db-backups
+  storageClassName: ceph-bucket

--- a/kubernetes/apps/nautobot/db/cluster.yaml
+++ b/kubernetes/apps/nautobot/db/cluster.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: nautobot-db
+spec:
+  # 3-instance HA: tolerates a single instance loss without breaking writes
+  # (minSyncReplicas: 1 needs at least one healthy standby to ack writes,
+  # which a 2-instance cluster can't guarantee).
+  instances: 3
+  # CNPG "standard" image — bundles pgvector, PGAudit, Failover Slots, locales, JIT.
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3-standard-trixie@sha256:9f9f53c9e07e5b2924945e6eaeb9168f7e856786d221839866ac85ccd703b3ba
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+  storage:
+    size: 20Gi
+    storageClass: ceph-block
+  superuserSecret:
+    name: nautobot-db-superuser
+  enableSuperuserAccess: true
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      memory: 2Gi
+  monitoring:
+    enablePodMonitor: true
+
+  managed:
+    roles:
+      - name: nautobot
+        ensure: present
+        login: true
+        passwordSecret:
+          name: nautobot-db-app-role
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: ceph-store
+        # Bump the version suffix when recovering from a prior cluster.
+        serverName: nautobot-db-v1
+
+  # When recovering from a prior cluster, uncomment and set source/serverName
+  # to the previous cluster's serverName.
+  # bootstrap:
+  #   recovery:
+  #     source: &previousCluster nautobot-db-v0
+  # externalClusters:
+  #   - name: *previousCluster
+  #     plugin:
+  #       name: barman-cloud.cloudnative-pg.io
+  #       parameters:
+  #         barmanObjectName: ceph-store
+  #         serverName: *previousCluster
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: nautobot-db-backup
+spec:
+  # CNPG schedule is a 6-field cron, SECONDS-FIRST (sec min hour dom mon dow).
+  # A 5-field "0 0 * * *" is read as every-hour and silently produces 24x the
+  # base backups. This is every 6h (00/06/12/18:00); PITR granularity comes from
+  # WAL archiving, so base-backup cadence only trades restore speed vs. storage.
+  schedule: "0 0 */6 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: nautobot-db
+  target: prefer-standby
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/nautobot/db/database.yaml
+++ b/kubernetes/apps/nautobot/db/database.yaml
@@ -1,0 +1,15 @@
+---
+# Declarative database. CNPG ensures the DB exists and is owned by the
+# `nautobot` role (created by `managed.roles` on the Cluster). Owner gets
+# implicit full privileges — no GRANT step needed. Nautobot runs its own
+# migrations on start and needs no preinstalled extensions.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: nautobot
+spec:
+  name: nautobot
+  owner: nautobot
+  cluster:
+    name: nautobot-db
+  ensure: present

--- a/kubernetes/apps/nautobot/db/externalsecret.yaml
+++ b/kubernetes/apps/nautobot/db/externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+# CNPG superuser secret. Password material lives in GCP Secret Manager
+# (provisioned by tofu in the private infra repo); this only projects it
+# into the shape CNPG expects (username/password) plus the s3-region the
+# barman ObjectStore signs backup requests with.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nautobot-db-superuser
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: "postgres"
+        password: "{{ .password }}"
+        # Ceph RGW doesn't enforce regions, but the AWS SDK requires a value
+        # to sign requests. Static is fine here.
+        s3-region: "us-east-1"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ${CLUSTER_NAME}-nautobot-db-superuser-password

--- a/kubernetes/apps/nautobot/db/kustomization.yaml
+++ b/kubernetes/apps/nautobot/db/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./app-role-externalsecret.yaml
+  - ./bucket.yaml
+  - ./objectstore.yaml
+  - ./cluster.yaml
+  - ./database.yaml

--- a/kubernetes/apps/nautobot/db/objectstore.yaml
+++ b/kubernetes/apps/nautobot/db/objectstore.yaml
@@ -1,0 +1,30 @@
+---
+# Barman target: Ceph RGW via the OBC-provisioned bucket.
+# - destinationPath uses the explicit bucket name set in bucket.yaml.
+# - access/secret come from the Rook-generated secret (`nautobot-db-bucket`).
+# - region comes from nautobot-db-superuser (templated to "us-east-1" — Ceph
+#   doesn't enforce a region, but the AWS SDK requires one for signing).
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: ceph-store
+spec:
+  configuration:
+    destinationPath: s3://nautobot-db-backups/
+    endpointURL: http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc:80
+    s3Credentials:
+      region:
+        name: nautobot-db-superuser
+        key: s3-region
+      accessKeyId:
+        name: nautobot-db-bucket
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: nautobot-db-bucket
+        key: AWS_SECRET_ACCESS_KEY
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    data:
+      compression: bzip2
+  retentionPolicy: "14d"

--- a/kubernetes/apps/nautobot/queue/dragonfly.yaml
+++ b/kubernetes/apps/nautobot/queue/dragonfly.yaml
@@ -1,0 +1,38 @@
+---
+# Dragonfly stands in for Redis — Nautobot uses it as both the Celery
+# broker/result backend and the Django cache. 3-replica HA: operator manages
+# failover and the Service routes to the current primary, so the web pods and
+# Celery workers/beat always reach a writable endpoint. Persistence is on so a
+# restart doesn't drop in-flight Celery tasks — RDB snapshot to a Ceph PVC
+# every 15 minutes.
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: nautobot-queue
+spec:
+  replicas: 3
+  authentication:
+    passwordFromSecret:
+      name: nautobot-queue-secrets
+      key: password
+  args:
+    - --proactor_threads=2
+    # Static snapshot filename (no {timestamp} macro) so each cron snapshot
+    # OVERWRITES the previous one, keeping exactly one file. The default
+    # `dump-{timestamp}` never prunes and eventually fills the PVC.
+    - --dbfilename=dump
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  snapshot:
+    cron: "*/15 * * * *"
+    persistentVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: ceph-block

--- a/kubernetes/apps/nautobot/queue/externalsecret.yaml
+++ b/kubernetes/apps/nautobot/queue/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# Password Secret shared by Dragonfly (its `authentication` field) and the
+# Nautobot HelmRelease (redis existingSecret). Single source of truth for the
+# broker password; value lives in GSM (tofu-managed in the private infra repo).
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nautobot-queue-secrets
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        password: "{{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ${CLUSTER_NAME}-nautobot-redis-password

--- a/kubernetes/apps/nautobot/queue/kustomization.yaml
+++ b/kubernetes/apps/nautobot/queue/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./dragonfly.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/nautobot/app.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/nautobot/app.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nautobot-app
+  namespace: &namespace nautobot
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  dependsOn:
+    - name: nautobot-db
+      namespace: nautobot
+    - name: nautobot-queue
+      namespace: nautobot
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/nautobot/app
+  interval: 1h
+  retryInterval: 2m
+  timeout: 15m
+  prune: true
+  wait: false

--- a/kubernetes/clusters/atlantis-k8s01/apps/nautobot/db.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/nautobot/db.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nautobot-db
+  namespace: &namespace nautobot
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: cnpg-system
+    - name: barman-cloud-plugin
+      namespace: cnpg-system
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/nautobot/db
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/apps/nautobot/external-secrets.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/nautobot/external-secrets.yaml
@@ -1,0 +1,29 @@
+---
+# Per-namespace GCP Secret Manager store for nautobot on atlantis-k8s01.
+# Authenticates to GSM via Workload Identity Federation as the namespace SA
+# (external-secrets-atlantis-k8s01). The IAM grant that lets this SA read the
+# nautobot-* secrets is tofu-managed in the PRIVATE infra repo — apply that
+# before these ExternalSecrets can sync.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-atlantis-k8s01
+  namespace: nautobot
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gcp-sm
+  namespace: nautobot
+spec:
+  provider:
+    gcpsm:
+      projectID: freckle-secrets-db8d4f
+      auth:
+        workloadIdentityFederation:
+          audience: //iam.googleapis.com/projects/305363951351/locations/global/workloadIdentityPools/k8s-clusters/providers/atlantis-k8s01
+          serviceAccountRef:
+            name: external-secrets-atlantis-k8s01
+            namespace: nautobot
+            audiences:
+              - //iam.googleapis.com/projects/305363951351/locations/global/workloadIdentityPools/k8s-clusters/providers/atlantis-k8s01

--- a/kubernetes/clusters/atlantis-k8s01/apps/nautobot/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/nautobot/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nautobot
+components:
+  - ../../../../components/flux-post-build-variables
+resources:
+  - ./external-secrets.yaml
+  - ./db.yaml
+  - ./queue.yaml
+  - ./app.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/nautobot/queue.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/nautobot/queue.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nautobot-queue
+  namespace: &namespace nautobot
+  labels:
+    infra.freckle.systems/post-build-variables: enabled
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: *namespace
+  dependsOn:
+    - name: dragonfly-operator
+      namespace: db
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/nautobot/queue
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/flux/nautobot.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/flux/nautobot.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nautobot
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nautobot-apps
+  namespace: &namespace nautobot
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-apps
+      namespace: external-secrets
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/clusters/atlantis-k8s01/apps/nautobot
+  interval: 2m
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: false


### PR DESCRIPTION
Deploys **Nautobot** as the DCIM source-of-truth on `atlantis-k8s01`, in a new `nautobot` namespace, following the repo's established 3-layer Flux structure.

## What's here

| Layer | Contents |
|---|---|
| `db/` | CNPG Postgres — 3-instance HA, barman WAL archiving to Ceph RGW, 6h `ScheduledBackup`; superuser + app-role creds from GSM |
| `queue/` | Dragonfly (Redis-compatible) as the Celery broker + Django cache; RDB snapshots to Ceph |
| `app/` | Nautobot HelmRelease from the **GHCR OCI chart** (`v3.1.2`, digest-pinned), image overridden to **`ghcr.io/nautobot/nautobot:3.1.8`** (digest-pinned); bundled postgres/redis off and wired to CNPG + Dragonfly; `HTTPRoute` on the tailnet gateway at `nautobot.${CLUSTER_DOMAIN}`; uploaded media on a shared `ceph-filesystem` RWX PVC |

## Design notes

- **Secrets → GSM** via per-namespace `gcp-sm` SecretStore + WIF SA (matches the observability/matrix pattern). Values and the IAM grant are tofu-managed in the private infra repo.
- **SSO → Nautobot-native OIDC** (`social_core.backends.open_id_connect.OpenIdConnectAuth`) pointed straight at Freckle ID (`https://freckle.id`) via a supplemental `nautobot_config.py`. No SecurityPolicy/auth proxy. The pocket-id client + its GSM secret are tofu-managed.
- **Persistence**: media on `ceph-filesystem` RWX; static is ephemeral (collected at start); git datasources use the chart's emptyDir and re-sync from remote. All DCIM state is in Postgres.

## Prerequisites (private infra repo — tofu)

This won't fully reconcile until the tofu side is applied:
1. `module.nautobot_eso` — secretAccessor grant for the `nautobot`-ns ESO SA over `atlantis-k8s01-nautobot-*`
2. `pocketid_client.nautobot` + `module.nautobot_oidc_secret` — OIDC client → GSM `atlantis-k8s01-nautobot-oidc`
3. Hand-created random GSM secrets: `atlantis-k8s01-nautobot-{db-superuser-password,db-app-password,redis-password,secret-key,superuser-password,superuser-apitoken}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new production-style footprint (HA DB, auth SSO, many secrets) with external tofu prerequisites; mis-synced GSM/IAM would block or weaken bootstrap until infra is applied.
> 
> **Overview**
> Adds a new **`nautobot`** namespace on **`atlantis-k8s01`** with Flux wiring (`flux/nautobot.yaml` plus cluster-local `db` / `queue` / `app` Kustomizations) for a full Nautobot DCIM stack.
> 
> **Data & messaging:** 3-node CNPG Postgres with barman backups to Ceph RGW (OBC + `ObjectStore`, 6h `ScheduledBackup`, 14d retention), declarative `Database` and GSM-backed superuser/app-role secrets shared with the app. **Dragonfly** (3 replicas, password auth, RDB snapshots) replaces bundled Redis for Celery and cache.
> 
> **Application:** Digest-pinned GHCR Helm chart and Nautobot **3.1.8** image; bundled Postgres/Redis disabled and pointed at CNPG and Dragonfly; media on **`ceph-filesystem` RWX**. Per-namespace **`gcp-sm`** SecretStore (WIF) projects Django, bootstrap admin, and OIDC creds from GSM. Supplemental config enables **Freckle ID** OIDC (`https://freckle.id`) with auto-provisioned **`sso`** group users. **`HTTPRoute`** exposes the service on the tailnet gateway at `nautobot.${CLUSTER_DOMAIN}`.
> 
> Reconciliation depends on tofu-managed GSM secrets and IAM in the private infra repo (not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec658a469addcaf91b9db6aee283ae2bbf5c042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->