### PR TITLE
nautobot: fix config replacing image default (missing GIT_ROOT)

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -12,9 +12,15 @@ spec:
     namespace: nautobot
   maxHistory: 2
   install:
+    # 10m (up from Helm's 5m default) so the migration hook Job has time to
+    # run all database migrations on a fresh install.
+    timeout: 10m
     remediation:
       retries: 3
   upgrade:
+    # Same headroom — the release already exists, so the fix rolls as an
+    # upgrade and migrations run in the upgrade hook.
+    timeout: 10m
     cleanupOnFail: true
     remediation:
       retries: 3
@@ -103,26 +109,39 @@ spec:
               name: nautobot-secrets
               key: client-secret
 
-      # Supplemental nautobot_config.py appended on top of Nautobot core
-      # settings (which already build DATABASES/CACHES/etc. from the NAUTOBOT_*
-      # env vars the chart injects from the values above). Wires SSO to Freckle
-      # ID (pocket-id) using the generic OIDC backend (backend name "oidc" ->
-      # SOCIAL_AUTH_OIDC_* settings). New OIDC users are auto-created and land
-      # in the "sso" group; grant permissions to that group in Nautobot.
+      # Full nautobot_config.py — setting this REPLACES the image's default
+      # config file entirely (the chart mounts it over /opt/nautobot/
+      # nautobot_config.py), so it must reproduce the image default's active
+      # lines first. The critical one is `from nautobot.core.settings import *`,
+      # which builds GIT_ROOT/DATABASES/CACHES/etc. from the NAUTOBOT_* env vars
+      # the chart injects. We then append the Freckle ID (pocket-id) SSO wiring:
+      # python-social-auth generic OIDC backend (name "oidc" -> SOCIAL_AUTH_OIDC_*).
+      # New OIDC users are auto-created into the "sso" group; grant that group
+      # object permissions in Nautobot.
       config: |
         import os
+        import sys
 
+        from nautobot.core.settings import *  # noqa: F401,F403
+        from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
+
+        if DATABASES["default"]["ENGINE"].endswith("mysql"):
+            DATABASES["default"]["OPTIONS"] = {"charset": "utf8mb4"}
+
+        SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "")
+
+        INSTALLATION_METRICS_ENABLED = is_truthy(os.getenv("NAUTOBOT_INSTALLATION_METRICS_ENABLED", "True"))
+
+        # --- Freckle ID (pocket-id) SSO ---
         AUTHENTICATION_BACKENDS = [
             "social_core.backends.open_id_connect.OpenIdConnectAuth",
             "nautobot.core.authentication.ObjectPermissionBackend",
         ]
-
         SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = "https://freckle.id"
         SOCIAL_AUTH_OIDC_KEY = os.environ.get("NAUTOBOT_OIDC_CLIENT_ID", "")
         SOCIAL_AUTH_OIDC_SECRET = os.environ.get("NAUTOBOT_OIDC_CLIENT_SECRET", "")
         # Store social-auth extra_data as a real JSONField (Postgres).
         SOCIAL_AUTH_JSONFIELD_ENABLED = True
-
         # Auto-provision SSO users into a default group so they can log in
         # before an admin assigns object permissions.
         EXTERNAL_AUTH_DEFAULT_GROUPS = ["sso"]


### PR DESCRIPTION
Follow-up fix to #2181. The Nautobot pods crashlooped with `AttributeError: module 'nautobot_config' has no attribute 'GIT_ROOT'`.

**Cause:** the chart mounts `nautobot.config` as a ConfigMap **over** the image's default `/opt/nautobot/nautobot_config.py`, replacing it. The image default's one essential job is `from nautobot.core.settings import *` (which builds `GIT_ROOT`/`DATABASES`/`CACHES`/… from the `NAUTOBOT_*` env vars the chart injects). My OIDC-only override dropped that import, so the settings module had no `GIT_ROOT`.

**Fix:** reproduce the image default's active lines (the `core.settings` import + the mysql tweak + `SECRET_KEY`/`INSTALLATION_METRICS`) and then append the Freckle ID OIDC block. Verified: `python -m py_compile` clean, kustomize build OK.

This touches only `apps/nautobot/app/helmrelease.yaml` (not the flux dir), so the pre-existing `infra-private` flux-local check shouldn't trip this time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live app bootstrap (Django settings and auth backends) and Helm release timing; misconfiguration could still break startup, but the change directly addresses a known production crash.
> 
> **Overview**
> Fixes Nautobot **crashloops** (`GIT_ROOT` missing) by changing the Helm `nautobot.config` block from an OIDC-only snippet to a **full** `nautobot_config.py` that matches what the chart mount replaces in the image.
> 
> The mounted config now starts with `from nautobot.core.settings import *` (plus the image-default mysql charset tweak, `SECRET_KEY`, and installation metrics), then keeps the existing Freckle ID OIDC / `sso` group wiring. Comments were updated to state that this value **fully replaces** the default file, not supplements it.
> 
> **Helm install and upgrade timeouts** are raised to **10m** so migration hook Jobs can finish on fresh installs and upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f234a22fbb3fbfe78004c3c4d415ef4cb540c28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->