### PR TITLE
nautobot: enable PKCE on the OIDC backend (Freckle ID requires it)

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -140,6 +140,9 @@ spec:
         SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = "https://freckle.id"
         SOCIAL_AUTH_OIDC_KEY = os.environ.get("NAUTOBOT_OIDC_CLIENT_ID", "")
         SOCIAL_AUTH_OIDC_SECRET = os.environ.get("NAUTOBOT_OIDC_CLIENT_SECRET", "")
+        # The pocket-id client requires PKCE. The generic OIDC backend supports
+        # it (BaseOAuth2PKCE) but defaults off, so enable it (S256 by default).
+        SOCIAL_AUTH_OIDC_USE_PKCE = True
         # Store social-auth extra_data as a real JSONField (Postgres).
         SOCIAL_AUTH_JSONFIELD_ENABLED = True
         # Auto-provision SSO users into a default group so they can log in


### PR DESCRIPTION
Follow-up to #2182. SSO login reached Freckle ID but failed with:

> This client requires PKCE, but the 'code_challenge' parameter is missing.

The pocket-id client is confidential **and PKCE-required** (matching the grafana/matrix clients), but the generic python-social-auth OIDC backend (`social_core` 4.9.1, extends `BaseOAuth2PKCE`) has `DEFAULT_USE_PKCE = False`, so it sent no `code_challenge`.

**Fix:** `SOCIAL_AUTH_OIDC_USE_PKCE = True` (S256 by default). One-line addition to the `nautobot.config` OIDC block. Verified: `py_compile` clean, kustomize build OK.

Same pre-existing `infra-private` flux-local artifact will show red; all correctness checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single auth config flag required by the IdP; tightens the OAuth flow rather than bypassing security.
> 
> **Overview**
> Fixes Nautobot SSO against Freckle ID (pocket-id) by turning on **PKCE** on the generic python-social-auth OIDC backend.
> 
> The IdP rejects authorization requests without `code_challenge`; the backend supports PKCE via `BaseOAuth2PKCE` but leaves it off by default. The embedded `nautobot.config` now sets **`SOCIAL_AUTH_OIDC_USE_PKCE = True`** (S256) in the existing Freckle ID OIDC block—no other SSO settings change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9414a4e712bf3d066bbb014a8194302a4257128d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->