### PR TITLE
nautobot: OIDC group sync + groups scope, drop default-group, install off

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -109,15 +109,29 @@ spec:
               name: nautobot-secrets
               key: client-secret
 
+      # SSO group sync. Nautobot core reads these NAUTOBOT_SSO_* env vars at
+      # settings-import time: it appends group_sync to SOCIAL_AUTH_PIPELINE,
+      # which reads the `groups` claim, auto-creates the matching Nautobot
+      # groups, and sets is_staff/is_superuser from the lists below. Non-secret,
+      # so plain extraVars (applied to all pods for consistent settings).
+      extraVars:
+        - name: NAUTOBOT_SSO_ENABLE_GROUP_SYNC
+          value: "true"
+        - name: NAUTOBOT_SSO_CLAIMS_GROUP
+          value: "groups"
+        - name: NAUTOBOT_SSO_STAFF_GROUPS
+          value: "nautobot_admins,nautobot_super_admins"
+        - name: NAUTOBOT_SSO_SUPERUSER_GROUPS
+          value: "nautobot_super_admins"
+
       # Full nautobot_config.py — setting this REPLACES the image's default
       # config file entirely (the chart mounts it over /opt/nautobot/
       # nautobot_config.py), so it must reproduce the image default's active
       # lines first. The critical one is `from nautobot.core.settings import *`,
       # which builds GIT_ROOT/DATABASES/CACHES/etc. from the NAUTOBOT_* env vars
       # the chart injects. We then append the Freckle ID (pocket-id) SSO wiring:
-      # python-social-auth generic OIDC backend (name "oidc" -> SOCIAL_AUTH_OIDC_*).
-      # New OIDC users are auto-created into the "sso" group; grant that group
-      # object permissions in Nautobot.
+      # python-social-auth generic OIDC backend (name "oidc" -> SOCIAL_AUTH_OIDC_*),
+      # with group sync driven by the NAUTOBOT_SSO_* extraVars above.
       config: |
         import os
         import sys
@@ -130,7 +144,8 @@ spec:
 
         SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY", "")
 
-        INSTALLATION_METRICS_ENABLED = is_truthy(os.getenv("NAUTOBOT_INSTALLATION_METRICS_ENABLED", "True"))
+        # Install/usage reporting off (image default is on).
+        INSTALLATION_METRICS_ENABLED = False
 
         # --- Freckle ID (pocket-id) SSO ---
         AUTHENTICATION_BACKENDS = [
@@ -145,6 +160,9 @@ spec:
         SOCIAL_AUTH_OIDC_USE_PKCE = True
         # Store social-auth extra_data as a real JSONField (Postgres).
         SOCIAL_AUTH_JSONFIELD_ENABLED = True
-        # Auto-provision SSO users into a default group so they can log in
-        # before an admin assigns object permissions.
-        EXTERNAL_AUTH_DEFAULT_GROUPS = ["sso"]
+        # Request the `groups` scope so pocket-id includes the user's group
+        # memberships in the token; group sync (NAUTOBOT_SSO_* extraVars) maps
+        # them to Nautobot groups + staff/superuser. Deliberately no
+        # EXTERNAL_AUTH_DEFAULT_GROUPS — it required a pre-existing group and
+        # logged "Group not found"; membership now comes from the claim.
+        SOCIAL_AUTH_OIDC_SCOPE = ["groups"]


### PR DESCRIPTION
Hardening pass on Nautobot SSO (pairs with freckleapps/infra#32 which adds the pocket-id groups + client restriction).

- **`groups` scope**: pocket-id only returns the `groups` claim when the client requests the scope (verified against the live token). Add `SOCIAL_AUTH_OIDC_SCOPE = ["groups"]`.
- **Group sync**: `NAUTOBOT_SSO_ENABLE_GROUP_SYNC=true` + claim/staff/superuser env. `group_sync` auto-creates the claimed groups and sets `is_staff`/`is_superuser` — `nautobot_super_admins` → superuser, `nautobot_admins`+`super_admins` → staff.
- **Drop `EXTERNAL_AUTH_DEFAULT_GROUPS = ["sso"]`** — it required a pre-existing group and logged `Group not found` on every login.
- **Install reporting off** (`INSTALLATION_METRICS_ENABLED = False`).

Same pre-existing `infra-private` flux-local artifact will show red; all correctness checks pass. `py_compile` + kustomize build clean.

⚠️ Before this deploys: assign yourself to `nautobot_super_admins` in Freckle ID (the client is now group-restricted).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication authorization (group sync, staff/superuser mapping); misconfiguration or missing Freckle ID group membership could block admin access after deploy.
> 
> **Overview**
> **Nautobot SSO** now maps Freckle ID group memberships into Nautobot roles instead of dropping every new user into a static `sso` group.
> 
> The Helm release adds **`NAUTOBOT_SSO_*` `extraVars`** to turn on core group sync from the `groups` claim, with **`nautobot_super_admins`** as superuser and **`nautobot_admins`** / **`nautobot_super_admins`** as staff. **`nautobot_config.py`** requests the **`groups` OIDC scope** (required for pocket-id to emit the claim) and **removes `EXTERNAL_AUTH_DEFAULT_GROUPS`** so logins no longer depend on a pre-created `sso` group. **Install/usage telemetry** is **hard-disabled** via `INSTALLATION_METRICS_ENABLED = False` instead of following the image default env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fceba5258bdac18ac689f96ea02ee7b71ca853ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->