### PR TITLE
nautobot: filter SSO group sync to nautobot_* groups

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -166,3 +166,28 @@ spec:
         # EXTERNAL_AUTH_DEFAULT_GROUPS — it required a pre-existing group and
         # logged "Group not found"; membership now comes from the claim.
         SOCIAL_AUTH_OIDC_SCOPE = ["groups"]
+
+        # pocket-id returns ALL of a user's groups in the `groups` claim, and the
+        # stock nautobot.extras.group_sync.group_sync creates every one of them —
+        # cluttering Nautobot with unrelated groups (jellyfin_users, sysadmins,
+        # ...). Replace that pipeline step with a prefix-filtered version so only
+        # nautobot_* groups sync and drive is_staff/is_superuser. (This module,
+        # nautobot_config, is importable by dotted path — /opt/nautobot is on
+        # sys.path — so the pipeline can reference the function below.)
+        def nautobot_group_sync(uid, user=None, response=None, *args, **kwargs):
+            from django.contrib.auth.models import Group
+
+            if not (user and response):
+                return
+            groups = [g for g in (response.get(SSO_CLAIMS_GROUP) or []) if g.startswith("nautobot_")]
+            user.groups.set([Group.objects.get_or_create(name=g)[0].id for g in groups])
+            user.is_superuser = any(g in SSO_SUPERUSER_GROUPS for g in groups)
+            user.is_staff = any(g in SSO_STAFF_GROUPS for g in groups)
+            user.save()
+
+        SOCIAL_AUTH_PIPELINE = tuple(
+            "nautobot_config.nautobot_group_sync"
+            if step == "nautobot.extras.group_sync.group_sync"
+            else step
+            for step in SOCIAL_AUTH_PIPELINE
+        )


### PR DESCRIPTION
pocket-id sends *all* of a user's groups in the `groups` claim, so the stock `group_sync` created every one as an empty Nautobot group (jellyfin_users, sysadmins, …). Replace the pipeline step with a prefix-filtered `nautobot_config.nautobot_group_sync` that only syncs `nautobot_*` groups (and still drives is_staff/is_superuser). Existing noise groups get cleaned up separately. py_compile + kustomize build clean; same infra-private CI artifact expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OIDC login group membership and staff/superuser flags; behavior is narrower than before but misconfiguration of prefix or staff lists could affect access.
> 
> **Overview**
> **SSO login** was creating a Nautobot group for every pocket-id group in the token claim, not just DCIM-related ones. This change swaps the default `group_sync` social-auth pipeline step for inline `nautobot_group_sync` in the Helm-mounted `nautobot_config.py`.
> 
> On each OIDC login, only claim groups with the `nautobot_` prefix are synced to Django groups; `is_staff` and `is_superuser` still follow the existing `NAUTOBOT_SSO_STAFF_GROUPS` / `NAUTOBOT_SSO_SUPERUSER_GROUPS` env configuration. Unrelated groups are no longer auto-created on login (cleanup of groups already created is out of band).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda49e1ceac2d5c5b05b82f1d855ad113e47c968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->