### PR TITLE
nautobot: disable superuser bootstrap + bump CPU/ease liveness probe

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -58,6 +58,25 @@ spec:
         storageClassName: ceph-filesystem
         accessMode: ReadWriteMany
         size: 5Gi
+
+      # The web pod's liveness probe runs `nautobot-server health_check`, which
+      # cold-boots all of Nautobot each time (~1 core for ~10s). At the chart's
+      # 1-core limit + 15s period that pegged the pod near a full core at idle
+      # and left no headroom, so any extra CPU pressure timed the probe out and
+      # crash-looped it. Give it 2 cores and halve the probe cadence (detection
+      # still ~90s at failureThreshold 3). Merges over the chart's probe (keeps
+      # enabled + exec command).
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1280M"
+        limits:
+          cpu: "2"
+          memory: "8704M"
+      livenessProbe:
+        periodSeconds: 30
+        timeoutSeconds: 20
+
       # Space-separated string (NAUTOBOT_ALLOWED_HOSTS). Left as "*" — the only
       # ingress path is the private tailnet gateway, and scoping it risks
       # rejecting the chart's in-pod health probes.
@@ -84,13 +103,15 @@ spec:
         existingSecret: nautobot-secrets
         existingSecretSecretKeyKey: secret-key
 
+      # Superuser bootstrap OFF — access is SSO-only now. Leaving this enabled
+      # would re-create/reset the local `admin` account on every upgrade,
+      # undoing the manual deactivation. Admin rights come from the
+      # nautobot_super_admins group via SSO group_sync. Deactivate (don't
+      # delete) the existing `admin` user in the UI to kill local login; it
+      # stays reactivatable as break-glass. The superuser GSM secrets remain
+      # but are now unused.
       superUser:
-        enabled: true
-        username: admin
-        email: nicole@freckle.family
-        existingSecret: nautobot-secrets
-        existingSecretPasswordKey: superuser-password
-        existingSecretApiTokenKey: superuser-apitoken
+        enabled: false
 
       # nautobot.metrics (NAUTOBOT_METRICS_ENABLED) defaults to true — the
       # Prometheus endpoint is already exposed; no override needed.


### PR DESCRIPTION
**Phase 2 (SSO-only) + resource fix.**

- `superUser.enabled=false` — access is SSO-only via the `nautobot_super_admins` group. Stops re-creating/resetting the local admin on upgrades. (Deactivate the existing `admin` user in the UI to close local login; kept reactivatable as break-glass.)
- Web pod → **2-core limit** (from 1), 500m request. The liveness probe is `nautobot-server health_check` (cold-boots all of Nautobot, ~1 core/~10s), which pegged the pod near a full core at idle and starved the probe under load. Raise liveness period 15→30s, timeout 15→20s.

Rendered + verified: limit cpu=2, liveness keeps its exec command at period 30, `NAUTOBOT_CREATE_SUPERUSER=false`. Same infra-private CI artifact expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabling superuser bootstrap changes how admin access is provisioned (SSO-only); incorrect SSO config could lock out admins until break-glass reactivation. CPU/probe tuning is a targeted availability fix with limited blast radius.
> 
> **Overview**
> **SSO-only (phase 2):** `superUser.enabled` is set to **false**, dropping the bootstrap `admin` user, email, and superuser secret keys so upgrades no longer recreate or reset the local admin account. Access stays via SSO (`nautobot_super_admins` / group sync); GSM superuser secrets are left in place but unused.
> 
> **Web pod stability:** Explicit **resources** are added (500m CPU request, **2** CPU limit, unchanged memory envelope) because the liveness probe runs `nautobot-server health_check`, which cold-starts Nautobot and was saturating a 1-core limit. **Liveness** is eased with **periodSeconds 30** and **timeoutSeconds 20** (chart exec probe unchanged) to reduce idle CPU pegging and probe timeouts under load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3596ca95238a066ac1789a956773eb08817a8970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->