### PR TITLE
nautobot: HTTPS security settings (secure cookies, SSL redirect, HSTS)

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -168,6 +168,21 @@ spec:
         # Install/usage reporting off (image default is on).
         INSTALLATION_METRICS_ENABLED = False
 
+        # --- HTTPS hardening (clears Django deploy warnings W004/W008/W012/W016) ---
+        # Nautobot runs behind the TLS-terminating tailnet gateway; Envoy sets
+        # X-Forwarded-Proto, so trust it to tell Django the request is secure —
+        # required for the secure-cookie / redirect / HSTS logic below to work
+        # (and to avoid a redirect loop with SECURE_SSL_REDIRECT).
+        SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+        SESSION_COOKIE_SECURE = True
+        CSRF_COOKIE_SECURE = True
+        SECURE_SSL_REDIRECT = True
+        # Exempt the health endpoint so the in-cluster readiness probe (plain
+        # HTTP, no X-Forwarded-Proto) still executes the checks instead of a 301.
+        SECURE_REDIRECT_EXEMPT = [r"^health"]
+        SECURE_HSTS_SECONDS = 31536000  # 1 year
+        SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+
         # --- Freckle ID (pocket-id) SSO ---
         AUTHENTICATION_BACKENDS = [
             "social_core.backends.open_id_connect.OpenIdConnectAuth",


### PR DESCRIPTION
Clears the Django `check --deploy` warnings W004/W008/W012/W016.

Nautobot is behind the TLS-terminating tailnet gateway, so:
- `SECURE_PROXY_SSL_HEADER` trusts Envoy's `X-Forwarded-Proto` (verified the gateway forwards it; HTTP:80 + HTTPS:443 listeners → no redirect loop)
- `SESSION_COOKIE_SECURE` / `CSRF_COOKIE_SECURE` = True
- `SECURE_SSL_REDIRECT` = True, with `SECURE_REDIRECT_EXEMPT = [^health]` so the readiness probe still executes over HTTP
- `SECURE_HSTS_SECONDS` = 1y + includeSubDomains

py_compile + kustomize build clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session/CSRF cookie and redirect behavior for all user traffic; misconfigured proxy headers or a bad health exempt could break login or probes.
> 
> **Overview**
> Adds **Django deploy hardening** to Nautobot’s supplemental `nautobot_config.py` so `check --deploy` warnings W004/W008/W012/W016 are cleared.
> 
> Because Nautobot sits behind the TLS-terminating tailnet gateway, the config trusts Envoy’s `X-Forwarded-Proto` via `SECURE_PROXY_SSL_HEADER`, then enables secure session/CSRF cookies, `SECURE_SSL_REDIRECT`, and one-year HSTS with subdomains. **`^health` is exempt** from the SSL redirect so in-cluster readiness probes over plain HTTP still run checks instead of getting a 301.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4caf78a06ec71ae1fd69572583586ddc23e1d7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->