### PR TITLE
nautobot: disable app-level SECURE_SSL_REDIRECT (gateway owns TLS)

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -176,10 +176,15 @@ spec:
         SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
         SESSION_COOKIE_SECURE = True
         CSRF_COOKIE_SECURE = True
-        SECURE_SSL_REDIRECT = True
-        # Exempt the health endpoint so the in-cluster readiness probe (plain
-        # HTTP, no X-Forwarded-Proto) still executes the checks instead of a 301.
-        SECURE_REDIRECT_EXEMPT = [r"^health"]
+        # App-level HTTP->HTTPS redirect stays OFF: the tailnet gateway is the
+        # only ingress and serves HTTPS exclusively, so external requests always
+        # arrive with X-Forwarded-Proto=https and would never be redirected
+        # anyway. The redirect only ever fired for header-less *in-cluster*
+        # clients (readiness probe, service-to-service API callers like dcim-ui),
+        # 301-ing them to an HTTPS URL whose cert doesn't cover the internal
+        # service name — friction with no security benefit. TLS enforcement lives
+        # at the gateway; secure cookies + HSTS below still apply.
+        SECURE_SSL_REDIRECT = False
         SECURE_HSTS_SECONDS = 31536000  # 1 year
         SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 


### PR DESCRIPTION
Nautobot sits behind the TLS-terminating tailnet gateway, which is the only ingress and serves HTTPS exclusively. External requests therefore always arrive with X-Forwarded-Proto=https and are never redirected. The app-level redirect only ever fired for header-less in-cluster clients — the readiness probe (already worked around with SECURE_REDIRECT_EXEMPT) and service-to-service API callers like dcim-ui, which reads its inventory from Nautobot's GraphQL API over the internal service name. For those it 301'd to an HTTPS URL whose gateway cert doesn't cover the internal name, breaking the call for no security gain.

TLS enforcement stays at the gateway; secure cookies + HSTS remain on. Drops the now-moot SECURE_REDIRECT_EXEMPT health exemption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Django security flag in a gateway-terminated deployment; external TLS enforcement is unchanged and secure cookies/HSTS remain enabled.
> 
> **Overview**
> **Turns off Django `SECURE_SSL_REDIRECT`** in Nautobot’s embedded `nautobot_config.py` and **removes** the `SECURE_REDIRECT_EXEMPT` health-probe workaround.
> 
> TLS stays on the tailnet gateway; **`SECURE_PROXY_SSL_HEADER`**, secure session/CSRF cookies, and HSTS are unchanged. The redirect only affected in-cluster HTTP clients without `X-Forwarded-Proto` (probes, internal callers such as dcim-ui’s GraphQL), sending them to HTTPS URLs the gateway cert doesn’t match—no benefit for traffic that already enters as HTTPS from the gateway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3376371d839354962fd9fbf2bb407b1cdd63b3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->