### PR TITLE
fix(envoy-gateway): apply vendored envoy CRDs on atlantis

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/envoy-gateway-system/envoy-gateway-crds.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/envoy-gateway-system/envoy-gateway-crds.yaml
@@ -1,0 +1,32 @@
+---
+# Applies the envoy-proxy CRDs from the chart's bundled crds subchart.
+# Kept off the HR because the HR uses crds: Skip — the chart's
+# gateway-api experimental CRDs conflict with the standard channel that
+# gateway-api-crds installs.
+#
+# Added to atlantis later than fairy. Atlantis had been running whatever
+# an older chart install left behind (controller-gen v0.18.0) while fairy
+# tracked the vendored set (v0.20.1), so newer SecurityPolicy fields such
+# as oidc.forwardIDToken existed on one cluster and not the other. Same
+# vendored files, same EG version on both — this just stops the two
+# clusters drifting apart.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app envoy-gateway-crds
+  namespace: &namespace envoy-gateway-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/networking/envoy-gateway/crds
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  retryInterval: 2m
+  timeout: 5m
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/apps/envoy-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/envoy-gateway-system/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../../../components/flux-post-build-variables
 resources:
   - ./envoy-gateway.yaml
+  - ./envoy-gateway-crds.yaml
   - ./gateway-api.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/gateway-system/gateways.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/gateway-system/gateways.yaml
@@ -14,6 +14,8 @@ spec:
   dependsOn:
     - name: envoy-gateway
       namespace: envoy-gateway-system
+    - name: envoy-gateway-crds
+      namespace: envoy-gateway-system
   targetNamespace: *namespace
   path: ./kubernetes/clusters/atlantis-k8s01/apps/gateway-system/gateways
   prune: true


### PR DESCRIPTION
## Problem

Atlantis has been running whatever envoy-proxy CRDs an old chart install left behind, while fairy tracks the vendored set. Same chart version (v1.8.2) and same controller on both clusters:

| | controller-gen | `oidc.forwardIDToken` | vendored CRDs applied? |
|---|---|---|---|
| fairy | v0.20.1 | ✅ | yes, via `envoy-gateway-crds.yaml` |
| atlantis | v0.18.0 | ❌ | **no KS referenced them** |

90696198 vendored the CRDs and wired them up on fairy, noting atlantis was unaffected because its CRDs already existed. That was true at the time; the cost is the two clusters have drifted since.

The practical failure mode: a manifest validates cleanly against the CRD **in this repo** and is then rejected by atlantis's apiserver with `strict decoding error: unknown field`. Found while writing a SecurityPolicy that uses `oidc.forwardIDToken`.

## Change

Mirror fairy's `envoy-gateway-crds` Kustomization onto atlantis, and add the matching `dependsOn` to the gateways KS so ordering matches fairy too. `prune: false`, as on fairy.

## Verification

Server-side dry-run against atlantis shows all 8 CRDs updating cleanly — additive, no rejections:

```
customresourcedefinition.apiextensions.k8s.io/backends.gateway.envoyproxy.io configured (server dry run)
... 8 total, all "configured"
```

Warnings about a missing `last-applied-configuration` annotation are expected (they were helm-created) and Flux SSA handles them.

## Risk

Touches shared infrastructure — every gateway on atlantis. Mitigating: these exact files have run on fairy for months against the same controller version, and CRD updates here are additive. Worth a look at the gateways after it reconciles.

**Merge this before #2212 (akvorado)**, which contains a SecurityPolicy that will be rejected without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates cluster-wide gateway CRDs on shared atlantis ingress infrastructure; changes are additive and already proven on fairy at the same controller version, but worth verifying gateways after reconcile.
> 
> **Overview**
> Atlantis was still using envoy-proxy CRDs left from an older Helm install while fairy applies the **vendored** set from `kubernetes/apps/networking/envoy-gateway/crds`, so fields like `oidc.forwardIDToken` on SecurityPolicy could exist on one cluster and fail strict validation on the other.
> 
> This PR adds a Flux `envoy-gateway-crds` Kustomization on atlantis (same path and `prune: false` as fairy), includes it in the envoy-gateway-system bundle, and makes `gateway-configs` **depend on** that KS before reconciling gateways so CRDs are in place first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e7fb85a3843a42cbf61f00b1a8ceb4b16eda31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->