### PR TITLE
feat(netflow): deploy akvorado flow collector to den1

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -1,0 +1,159 @@
+---
+# Single Akvorado configuration file. Only the orchestrator mounts it — it
+# serves the resolved config to the inlet, outlet and console over HTTP, which
+# is why those three take the orchestrator URL as their only argument.
+#
+# Derived from upstream's config/akvorado.yaml + config/{inlet,outlet,console}.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: akvorado-config
+data:
+  akvorado.yaml: |
+    kafka:
+      topic: flows
+      brokers:
+        - kafka:9092
+      topic-configuration:
+        # Kafka is only a buffer in front of ClickHouse, so one day of
+        # retention on a single unreplicated broker is deliberate.
+        num-partitions: 4
+        replication-factor: 1
+        config-entries:
+          segment.bytes: 1073741824
+          retention.ms: 86400000
+          cleanup.policy: delete
+          compression.type: producer
+
+    geoip:
+      # Loaded by the orchestrator, which pushes the data into ClickHouse as
+      # dictionaries; the outlet never reads these files. Optional so a failed
+      # database download degrades enrichment instead of blocking startup.
+      optional: true
+      asn-database:
+        - /usr/share/GeoIP/asn.mmdb
+      geo-database:
+        - /usr/share/GeoIP/country.mmdb
+
+    clickhousedb:
+      servers:
+        - clickhouse:9000
+
+    clickhouse:
+      orchestrator-url: http://akvorado-orchestrator:8080
+      prometheus-endpoint: /metrics
+      # Names our own prefixes so flows involving them are labelled rather
+      # than lumped in with the internet. Roles are a first pass and cheap to
+      # refine once we see how the console groups things.
+      networks:
+        10.140.0.0/16:
+          name: den1-lan
+          role: internal
+          site: den1
+          tenant: freckle
+        172.20.0.0/20:
+          name: den1-mgmt
+          role: management
+          site: den1
+          tenant: freckle
+        172.25.0.0/20:
+          name: den1-infra
+          role: infrastructure
+          site: den1
+          tenant: freckle
+        172.26.0.0/20:
+          name: den1-infra
+          role: infrastructure
+          site: den1
+          tenant: freckle
+        # Public blocks come from the site-public-ips secret via postBuild so
+        # they stay out of this public repo, same as the cilium CIDR groups.
+        ${SITE_ATLANTIS_PUBLIC_V4_BLOCK}:
+          name: den1-public
+          role: dmz
+          site: den1
+          tenant: freckle
+        ${SITE_ATLANTIS_PUBLIC_V6_BLOCK}:
+          name: den1-public
+          role: dmz
+          site: den1
+          tenant: freckle
+
+    inlet:
+      flow:
+        inputs:
+          - type: udp
+            decoder: netflow
+            listen: :2055
+            workers: 2
+            receive-buffer: 212992
+          # border1.den1 exports IPFIX here.
+          - type: udp
+            decoder: netflow
+            listen: :4739
+            workers: 2
+            receive-buffer: 212992
+          - type: udp
+            decoder: sflow
+            listen: :6343
+            workers: 2
+            receive-buffer: 212992
+
+    outlet:
+      # No `routing` block, but note that does NOT mean routing is off: the
+      # provider defaults to bmp and there is no "none" option, so the outlet
+      # listens on :10179 for a BMP session that will never arrive. Nothing
+      # exposes that port, so it idles harmlessly.
+      #
+      # We deliberately don't peer it. border1.den1 reaches the internet over
+      # a static default route, not BGP, so it holds no DFZ table and BMP
+      # would contribute nothing to AS attribution. That comes from the IPinfo
+      # ASN database instead — the resolved `core.asn-providers` chain is
+      # [flow, routing, geo-ip], and ipt_NETFLOW populates no AS fields, so
+      # geo-ip is what actually answers.
+      metadata:
+        providers:
+          # Interface names/descriptions/speeds are polled over SNMPv2 from
+          # the exporter. border1.den1 already serves this community read-only.
+          - type: snmp
+            credentials:
+              ::/0:
+                communities:
+                  - freckle-public
+      core:
+        exporter-classifiers:
+          # SNMP sysName is "border1.den1", so the trailing label is the site.
+          - ClassifySiteRegex(Exporter.Name, "\\.([^.]+)$", "$1")
+          - ClassifyRole("edge")
+          - ClassifyTenant("freckle")
+        interface-classifiers:
+          # Upstream's default rule, which already fits our descriptions:
+          # eth0 is "Transit: Summit Hosting" -> connectivity=transit,
+          # provider=Summit, boundary=external. The spine links ("spine1.den1",
+          # "spine2.den1") fall through to internal.
+          - |
+            ClassifyConnectivityRegex(Interface.Description, "^(?i)(transit|pni|ppni|ix):? ", "$1") &&
+            ClassifyProviderRegex(Interface.Description, "^\\S+?\\s(\\S+)", "$1") &&
+            ClassifyExternal()
+          - ClassifyInternal()
+
+    console:
+      auth:
+        headers:
+          login: Remote-User
+          name: Remote-Name
+          email: Remote-Email
+        # No `default-user` here. Upstream documents setting its `login` to
+        # an empty string to refuse unauthenticated requests, and the console
+        # middleware does implement exactly that — but the field carries a
+        # `required` validation tag, so the orchestrator rejects the whole
+        # config at startup before the console ever sees it (verified against
+        # 2.4.1 with `orchestrator --check`). Omitting the block leaves the
+        # built-in `__default` identity in place for requests arriving without
+        # headers.
+        #
+        # Access control therefore rests entirely on the SecurityPolicy in
+        # oidc.yaml. Traffic that reaches the console Service directly from
+        # inside the cluster bypasses it — the same posture as every other
+        # OIDC-gated UI here (bazarr, radarr, ...), which are likewise
+        # protected at the gateway only.

--- a/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
@@ -1,0 +1,281 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# Akvorado's four services in one release. They share a single config file
+# (mounted only on the orchestrator, which serves it to the others over HTTP),
+# so they are one application even though they scale and fail independently.
+#
+#   inlet  -> kafka -> outlet -> clickhouse <- console
+#                                    ^
+#                              orchestrator (schema + geoip dictionaries)
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: akvorado
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: default
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled
+  values:
+    controllers:
+      # Owns the ClickHouse schema and serves configuration to the rest.
+      # Upgrade order per upstream: orchestrator first, then inlet/outlet,
+      # then console — Flux rolls them together, which is fine for a
+      # single-instance deployment.
+      orchestrator:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: &image
+              repository: quay.io/akvorado/akvorado
+              tag: 2.4.1@sha256:8acf8b7312ee3331bf4d348678949d4dcb134b533a1c882beb830b6d7d8a8428
+            args:
+              - orchestrator
+              - /etc/akvorado/akvorado.yaml
+            probes: &probes
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["/usr/local/bin/akvorado", "healthcheck"]
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+            securityContext: &containerSecurity
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+          # Keeps the IPinfo country/ASN databases fresh in a volume shared
+          # with the orchestrator. The token below is the public one upstream
+          # ships in docker-compose-ipinfo.yml for the free databases — it is
+          # not a credential of ours.
+          geoip:
+            image:
+              repository: quay.io/akvorado/ipinfo-geoipupdate
+              tag: latest@sha256:8e0c29dd857afc62969bbefefd768809780829767446c5ddac7f25b88957d476
+            env:
+              IPINFO_TOKEN: a2632ea59736c7
+              IPINFO_DATABASES: country asn
+              UPDATE_FREQUENCY: 48h
+            securityContext: *containerSecurity
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+
+      # Receives flow packets and hands them to Kafka unparsed.
+      inlet:
+        containers:
+          app:
+            image: *image
+            args:
+              - inlet
+              - http://akvorado-orchestrator:8080
+            probes: *probes
+            securityContext: *containerSecurity
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+      # Parses flows, enriches via SNMP, writes to ClickHouse. The heaviest
+      # of the four.
+      outlet:
+        containers:
+          app:
+            image: *image
+            args:
+              - outlet
+              - http://akvorado-orchestrator:8080
+            env:
+              # Surviving a restart avoids re-polling SNMP for every exporter
+              # and re-learning IPFIX templates before flows can be decoded.
+              AKVORADO_CFG_OUTLET_METADATA_CACHEPERSISTFILE: /run/akvorado/metadata.cache
+              AKVORADO_CFG_OUTLET_FLOW_STATEPERSISTFILE: /run/akvorado/flow.state
+            probes: *probes
+            securityContext: *containerSecurity
+            resources:
+              requests:
+                cpu: 200m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+      # Web UI. Authentication is handled entirely by the gateway.
+      console:
+        containers:
+          app:
+            image: *image
+            args:
+              - console
+              - http://akvorado-orchestrator:8080
+            env:
+              AKVORADO_CFG_CONSOLE_DATABASE_DSN: /run/akvorado/console.sqlite
+            probes: *probes
+            securityContext: *containerSecurity
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    service:
+      orchestrator:
+        controller: orchestrator
+        ports:
+          http:
+            port: &port 8080
+      # The inlet's flow-receiving ports are a separate hand-written
+      # LoadBalancer (see service-inlet.yaml) because app-template cannot set
+      # externalTrafficPolicy, which we need to preserve the exporter's
+      # source IP. This one is just the HTTP API/metrics.
+      inlet:
+        controller: inlet
+        ports:
+          http:
+            port: *port
+      outlet:
+        controller: outlet
+        ports:
+          http:
+            port: *port
+      console:
+        controller: console
+        ports:
+          http:
+            port: *port
+
+    serviceMonitor:
+      orchestrator: &metrics
+        serviceName: akvorado-orchestrator
+        endpoints:
+          - port: http
+            path: /api/v0/metrics
+      inlet:
+        <<: *metrics
+        serviceName: akvorado-inlet
+      outlet:
+        <<: *metrics
+        serviceName: akvorado-outlet
+      console:
+        <<: *metrics
+        serviceName: akvorado-console
+
+    route:
+      console:
+        hostnames:
+          - "akvorado.${CLUSTER_SVCS_DOMAIN}"
+        parentRefs:
+          - name: tailnet
+            namespace: gateway-system
+        rules:
+          - backendRefs:
+              - identifier: console
+                port: *port
+
+    persistence:
+      config:
+        type: configMap
+        name: akvorado-config
+        advancedMounts:
+          orchestrator:
+            app:
+              - path: /etc/akvorado/akvorado.yaml
+                subPath: akvorado.yaml
+                readOnly: true
+      # Shared between the updater and the orchestrator. Not persisted: the
+      # databases are re-downloaded on start and are not our data.
+      geoip:
+        type: emptyDir
+        advancedMounts:
+          orchestrator:
+            app:
+              - path: /usr/share/GeoIP
+                readOnly: true
+            geoip:
+              - path: /data
+      # Every container has a read-only root filesystem, so anything that
+      # writes needs an explicit volume.
+      outlet-state:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        retain: true
+        suffix: outlet-state
+        advancedMounts:
+          outlet:
+            app:
+              - path: /run/akvorado
+      console-db:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        retain: true
+        suffix: console-db
+        advancedMounts:
+          console:
+            app:
+              - path: /run/akvorado
+      # Upstream's compose gives the inlet a /run/akvorado too. Nothing in our
+      # config points at a file there, but the root filesystem is read-only so
+      # provide it rather than risk a write failing at runtime. Not persisted:
+      # unlike the outlet, the inlet keeps no state worth surviving a restart.
+      inlet-run:
+        type: emptyDir
+        advancedMounts:
+          inlet:
+            app:
+              - path: /run/akvorado
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          orchestrator:
+            app: &tmpMount
+              - path: /tmp
+            geoip: *tmpMount
+          inlet:
+            app: *tmpMount
+          outlet:
+            app: *tmpMount
+          console:
+            app: *tmpMount

--- a/kubernetes/apps/networking/netflow/akvorado/kustomization.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - helmrelease.yaml
+  - service-inlet.yaml
+  - oidc.yaml

--- a/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
@@ -1,0 +1,85 @@
+---
+# OIDC client credentials for the Akvorado console. 1Password item `akvorado`
+# must have oidc_client_id and oidc_client_secret fields. Register the client
+# in pocket-id with redirect URI
+# https://akvorado.atlantis.freckle.services/oauth2/callback before deploying.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: akvorado-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: op-cluster-vault
+  target:
+    template:
+      data:
+        client-id: "{{ .oidc_client_id }}"
+        client-secret: "{{ .oidc_client_secret }}"
+  dataFrom:
+    - extract:
+        key: akvorado
+---
+# The console has no authentication of its own — it trusts a Remote-User
+# header and assumes something in front established the identity. That makes
+# this policy load-bearing, not defence in depth.
+#
+# Two filters cooperate. Envoy Gateway orders oauth2 (8) before jwt_authn (9),
+# so:
+#   1. `oidc` challenges the browser against pocket-id and, once authenticated,
+#      injects the ID token as `Authorization: Bearer ...`.
+#   2. `jwt` validates that token against pocket-id's JWKS and copies claims
+#      into the headers the console reads.
+#
+# The targetRef is the bare `akvorado` HTTPRoute: app-template drops the key
+# suffix when a release declares a single route. If that ever becomes
+# `akvorado-console`, this policy silently stops applying and the console is
+# exposed — check `kubectl get securitypolicy` status after chart upgrades.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: akvorado-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: akvorado
+  oidc:
+    provider:
+      issuer: https://freckle.id
+    clientIDRef:
+      group: ""
+      kind: Secret
+      name: akvorado-oidc
+    clientSecret:
+      group: ""
+      kind: Secret
+      name: akvorado-oidc
+    redirectURL: https://akvorado.${CLUSTER_SVCS_DOMAIN}/oauth2/callback
+    logoutPath: /logout
+    scopes:
+      - openid
+      - email
+      - profile
+    # Hands the ID token to the JWT filter below. Without this the claims
+    # never reach the console and every session would be anonymous.
+    forwardIDToken:
+      header: Authorization
+  jwt:
+    providers:
+      - name: pocket-id
+        issuer: https://freckle.id
+        remoteJWKS:
+          uri: https://freckle.id/.well-known/jwks.json
+        # No `audiences`: the audience of an ID token is the client ID, which
+        # lives in a secret and cannot be templated in here. Issuer and
+        # signature validation against pocket-id's JWKS is the real check, and
+        # the token only ever arrives from the oidc filter above.
+        claimToHeaders:
+          - claim: preferred_username
+            header: Remote-User
+          - claim: name
+            header: Remote-Name
+          - claim: email
+            header: Remote-Email

--- a/kubernetes/apps/networking/netflow/akvorado/service-inlet.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/service-inlet.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/core/service_v1.json
+#
+# Flow ingest endpoint. Hand-written rather than rendered by app-template
+# because that chart has no way to set externalTrafficPolicy, and we need it:
+# Akvorado identifies an exporter by the source IP of its flow packets, then
+# polls that address over SNMP for interface names. Under the default
+# `Cluster` policy the source is SNAT'd to a node IP, which would both
+# mis-identify the exporter and send SNMP at the wrong host.
+#
+# Selector labels are app-template's controller scheme, verified against the
+# rendered chart output.
+apiVersion: v1
+kind: Service
+metadata:
+  name: akvorado-inlet-flows
+  labels:
+    ipam.freckle.systems/lb-pool: internal
+  annotations:
+    # Pinned, not IPAM's choice: border1.den1 hardcodes this address as its
+    # IPFIX collector, and that config lives in a different repo. If the
+    # Service were recreated and picked up a new IP, flow export would stop
+    # silently — the router would keep sending into a black hole.
+    lbipam.cilium.io/ips: 10.140.250.10
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  # IPv4 only: the exporter sends from 10.140.0.68 over v4. Add v6 here and
+  # a matching `server` block on the router if we ever export over v6.
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+  selector:
+    app.kubernetes.io/controller: inlet
+    app.kubernetes.io/instance: akvorado
+    app.kubernetes.io/name: akvorado
+  ports:
+    - name: netflow
+      port: 2055
+      targetPort: 2055
+      protocol: UDP
+    # border1.den1 exports IPFIX here.
+    - name: ipfix
+      port: 4739
+      targetPort: 4739
+      protocol: UDP
+    - name: sflow
+      port: 6343
+      targetPort: 6343
+      protocol: UDP

--- a/kubernetes/apps/networking/netflow/clickhouse/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/clickhouse/configmap.yaml
@@ -1,0 +1,81 @@
+---
+# ClickHouse server overrides for the Akvorado flow store. Both files are
+# dropped into config.d/ where ClickHouse merges them over its shipped
+# defaults. Content follows upstream Akvorado's docker/clickhouse/*.xml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-config
+data:
+  # ClickHouse's own system logs are unbounded by default and will happily
+  # eat the data volume alongside the flow tables. Cap every one of them at
+  # 30 days.
+  akvorado.xml: |
+    <clickhouse>
+     <asynchronous_metric_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </asynchronous_metric_log>
+     <metric_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </metric_log>
+     <part_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </part_log>
+     <text_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </text_log>
+     <query_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </query_log>
+     <query_thread_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </query_thread_log>
+     <query_metric_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </query_metric_log>
+     <query_views_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </query_views_log>
+     <trace_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </trace_log>
+     <error_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </error_log>
+     <latency_log>
+      <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+     </latency_log>
+    </clickhouse>
+  # Prometheus scrape endpoint on the HTTP port, and JSON logs to stdout so
+  # they land in victoria-logs like every other workload rather than in a
+  # file inside the container.
+  observability.xml: |
+    <clickhouse>
+     <prometheus>
+      <endpoint>/metrics</endpoint>
+      <metrics>true</metrics>
+      <events>true</events>
+      <asynchronous_metrics>true</asynchronous_metrics>
+     </prometheus>
+     <logger>
+       <level>fatal</level>
+       <errorlog remove="1"></errorlog>
+       <console>1</console>
+       <console_log_level>information</console_log_level>
+       <formatting>
+         <type>json</type>
+         <names>
+           <date_time>date_time</date_time>
+           <date_time_utc>date_time_utc</date_time_utc>
+           <thread_name>thread_name</thread_name>
+           <thread_id>thread_id</thread_id>
+           <level>level</level>
+           <query_id>query_id</query_id>
+           <logger_name>logger_name</logger_name>
+           <message>message</message>
+           <source_file>source_file</source_file>
+           <source_line>source_line</source_line>
+         </names>
+       </formatting>
+     </logger>
+    </clickhouse>

--- a/kubernetes/apps/networking/netflow/clickhouse/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/clickhouse/helmrelease.yaml
@@ -1,0 +1,128 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clickhouse
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: default
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled
+  values:
+    controllers:
+      clickhouse:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: clickhouse/clickhouse-server
+              tag: 26.3@sha256:1e108ceeaa1c5d46ee1423e9b56f960b25305319e9440fddf1d8fa616a16fc6a
+            env:
+              # Akvorado's orchestrator connects as the stock `default` user
+              # with no password, so skip the entrypoint's user provisioning
+              # entirely. Reachable only from inside the namespace.
+              CLICKHOUSE_SKIP_USER_SETUP: "1"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: &httpPort 8123
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *httpPort
+                  periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              # Upstream's compose grants SYS_NICE so ClickHouse can lower the
+              # priority of background merge threads. It degrades gracefully
+              # without it (logs "Cannot set 'nice'" and carries on), so we
+              # keep the drop-ALL baseline rather than widen capabilities for
+              # a scheduling nicety.
+              capabilities: { drop: ["ALL"] }
+              # The image entrypoint creates and chowns paths outside the data
+              # volume (/var/log/clickhouse-server, /tmp, user_files) before
+              # handing off to the server, so the root filesystem has to stay
+              # writable.
+              readOnlyRootFilesystem: false
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                memory: 8Gi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        # uid/gid 101 is the `clickhouse` user baked into the official image.
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: clickhouse
+        ports:
+          http:
+            port: *httpPort
+          native:
+            port: 9000
+    serviceMonitor:
+      app:
+        serviceName: clickhouse
+        endpoints:
+          - port: http
+            path: /metrics
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 100Gi
+        retain: true
+        suffix: data
+        advancedMounts:
+          clickhouse:
+            app:
+              - path: /var/lib/clickhouse
+      config:
+        type: configMap
+        name: clickhouse-config
+        advancedMounts:
+          clickhouse:
+            app:
+              - path: /etc/clickhouse-server/config.d/akvorado.xml
+                subPath: akvorado.xml
+                readOnly: true
+              - path: /etc/clickhouse-server/config.d/observability.xml
+                subPath: observability.xml
+                readOnly: true

--- a/kubernetes/apps/networking/netflow/clickhouse/kustomization.yaml
+++ b/kubernetes/apps/networking/netflow/clickhouse/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/networking/netflow/kafka/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/kafka/helmrelease.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# Single-node Kafka in KRaft mode, dedicated to the Akvorado flow pipeline.
+# It is a buffer between the inlet and the outlet, not a general-purpose bus:
+# retention is one day and every replication factor is 1, so losing it costs
+# at most a day of not-yet-ingested flows. Environment is transcribed from
+# upstream Akvorado's docker/docker-compose.yml.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kafka
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: default
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled
+  values:
+    controllers:
+      kafka:
+        type: statefulset
+        containers:
+          app:
+            image:
+              repository: apache/kafka
+              tag: 4.2.0@sha256:b5556544da1dccd04f03690107a233c37dbfd01d66e28ffdfc4fafba9b6e5039
+            env:
+              # KRaft: this single node is both controller and broker.
+              KAFKA_NODE_ID: "1"
+              KAFKA_PROCESS_ROLES: controller,broker
+              KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+              # Listeners. CLIENT is advertised as the Service name, which is
+              # how the akvorado inlet and outlet reach it.
+              KAFKA_LISTENERS: CLIENT://:9092,CONTROLLER://:9093
+              KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CLIENT:PLAINTEXT,CONTROLLER:PLAINTEXT
+              KAFKA_ADVERTISED_LISTENERS: CLIENT://kafka:9092
+              KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+              KAFKA_INTER_BROKER_LISTENER_NAME: CLIENT
+              # Single node: nothing to replicate onto.
+              KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+              KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+              KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+              KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: "1"
+              KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: "1"
+              KAFKA_DELETE_TOPIC_ENABLE: "true"
+              KAFKA_LOG_DIRS: /var/lib/kafka/data
+              # Pinned below the container memory limit so the JVM can't be
+              # OOM-killed by growing its heap into the cgroup ceiling.
+              KAFKA_HEAP_OPTS: -Xmx1536m -Xms1536m
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &clientPort 9092
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *clientPort
+                  periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+              # The image's entrypoint generates server.properties under
+              # /opt/kafka/config at startup, so the root filesystem must be
+              # writable.
+              readOnlyRootFilesystem: false
+            resources:
+              requests:
+                cpu: 200m
+                memory: 1Gi
+              limits:
+                memory: 3Gi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        # uid/gid 1000 is the `appuser` account in the apache/kafka image.
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: kafka
+        ports:
+          client:
+            port: *clientPort
+          controller:
+            port: 9093
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        retain: true
+        suffix: data
+        advancedMounts:
+          kafka:
+            app:
+              - path: /var/lib/kafka/data

--- a/kubernetes/apps/networking/netflow/kafka/kustomization.yaml
+++ b/kubernetes/apps/networking/netflow/kafka/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/akvorado.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/akvorado.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app akvorado
+  namespace: &namespace netflow
+  # Deliberately NOT labelled `infra.freckle.systems/post-build-variables`.
+  # That component patches `substituteFrom` as a whole list, and because a
+  # Flux Kustomization is a CRD the patch replaces rather than merges — it
+  # would drop the site-public-ips entry below without any error. The
+  # component's three sources are therefore spelled out here instead.
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  # Both are hard dependencies at startup: the orchestrator creates the Kafka
+  # topic and migrates the ClickHouse schema before anything else can run.
+  # Waiting on them also gives the site-public-ips ExternalSecret below plenty
+  # of time to land before this Kustomization needs it for substitution.
+  dependsOn:
+    - name: clickhouse
+      namespace: netflow
+    - name: kafka
+      namespace: netflow
+  targetNamespace: *namespace
+  path: ./kubernetes/apps/networking/netflow/akvorado
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  wait: true
+  postBuild:
+    substituteFrom:
+      # The standard three, mirroring components/flux-post-build-variables.
+      # CLUSTER_SVCS_DOMAIN comes from here.
+      - kind: ConfigMap
+        name: k8s-cluster-info
+      - kind: Secret
+        name: k8s-cluster-secrets
+      - kind: Secret
+        name: namespace-post-build-secrets
+        optional: true
+      # Supplies SITE_ATLANTIS_PUBLIC_V4_BLOCK / _V6_BLOCK for the network
+      # naming in akvorado.yaml, same source the cilium CIDR groups use.
+      - kind: Secret
+        name: site-public-ips

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/clickhouse.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/clickhouse.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clickhouse
+  namespace: &namespace netflow
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  targetNamespace: *namespace
+  path: ./kubernetes/apps/networking/netflow/clickhouse
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/kafka.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/kafka.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kafka
+  namespace: &namespace netflow
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  targetNamespace: *namespace
+  path: ./kubernetes/apps/networking/netflow/kafka
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: netflow
+components:
+  - ../../../../components/flux-post-build-variables
+resources:
+  - ./site-public-ips.yaml
+  - ./clickhouse.yaml
+  - ./kafka.yaml
+  - ./akvorado.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/site-public-ips.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/site-public-ips.yaml
@@ -1,0 +1,24 @@
+---
+# Site public IP blocks, needed here so the akvorado Kustomization can
+# substitute them into its network naming without those prefixes appearing in
+# this public repo. Same 1Password item the kube-system copy uses; the two are
+# independent projections of one source, not a shared secret.
+#
+# Applied by the parent netflow-apps Kustomization rather than by the akvorado
+# one that consumes it — a Kustomization cannot create the Secret its own
+# postBuild substitution depends on.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: site-public-ips
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: op-shared-vault
+  target:
+    name: site-public-ips
+  dataFrom:
+    - extract:
+        key: site-public-ips

--- a/kubernetes/clusters/atlantis-k8s01/flux/netflow.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/flux/netflow.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netflow
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app netflow-apps
+  namespace: &namespace netflow
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-apps
+      namespace: external-secrets
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/clusters/atlantis-k8s01/apps/netflow
+  interval: 2m
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: false


### PR DESCRIPTION
> ⚠️ **Merge #2211 first.** The SecurityPolicy here uses `oidc.forwardIDToken`, which atlantis's current CRDs don't have.

## Why

We can see how much traffic crosses the den1 transit link but never what it is or whose it is — interface counters are the end of the story today. [Akvorado](https://github.com/akvorado/akvorado) ingests IPFIX from `border1.den1`, enriches it with SNMP interface names and IPinfo ASN/geo data, and stores it in ClickHouse behind a query console.

## What

New `netflow` namespace on atlantis, three Kustomizations:

- **clickhouse** — single node, 100Gi ceph-block, upstream's system-log TTLs + Prometheus endpoint + JSON logs to stdout
- **kafka** — single-node KRaft, 20Gi. A one-day buffer in front of ClickHouse, not a general-purpose bus, so single replicas and replication factor 1 are deliberate
- **akvorado** — orchestrator (+ GeoIP updater sidecar), inlet, outlet, console in one release

Console at `akvorado.atlantis.freckle.services` on the tailnet gateway, behind freckle.id SSO.

## Two things worth knowing when touching this

**The inlet's flow LoadBalancer is hand-written**, not rendered by app-template, because it needs `externalTrafficPolicy: Local`. Akvorado identifies an exporter by the source IP of its flow packets and then polls *that* address over SNMP; the default `Cluster` policy would SNAT it to a node IP and break both. Its address is pinned with `lbipam.cilium.io/ips` because the router config that targets it lives in another repo — lose the pin and flow export dies silently.

**The akvorado Kustomization spells out its `substituteFrom` list** instead of using the `flux-post-build-variables` component. That component patches the list as a whole, and on a CRD the patch replaces rather than merges, which would silently drop the `site-public-ips` entry and leave `${SITE_ATLANTIS_PUBLIC_V4_BLOCK}` unsubstituted.

## Security note

The console has **no authentication of its own** — it trusts a `Remote-User` header — so the SecurityPolicy is load-bearing, not defence in depth. Envoy Gateway orders its oauth2 filter (8) before jwt_authn (9), which lets the OIDC flow hand its ID token to a JWT provider that maps claims into the headers the console reads.

Upstream documents setting `default-user.login: ""` to refuse unauthenticated requests, and the console middleware implements exactly that — but the field carries a `required` validation tag, so the orchestrator rejects the whole config at startup. The block is omitted, which means **traffic reaching the console Service directly from inside the cluster bypasses authentication**. Same posture as every other OIDC-gated UI here (bazarr, radarr, …); closing it properly is a fleet-wide CNP question rather than an Akvorado one.

## Verification done

- Config validated with the real image: `orchestrator --check` passes, `--dump` confirms brokers, SNMP community, classifiers, networks and retention all resolve as intended
- Chart rendered locally to confirm resource names and volume wiring
- Server-side dry-run against atlantis for the ConfigMap, Service, ExternalSecret and HelmRelease
- SecurityPolicy validated against the CRD schema #2211 installs

## Prerequisites before the console works

1. Register a pocket-id client with callback `https://akvorado.atlantis.freckle.services/oauth2/callback`
2. Create 1Password item `akvorado` with `oidc_client_id` + `oidc_client_secret`

Router-side flow export is a separate change in the private repo and must be applied only after this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new data pipeline plus load-bearing gateway auth; console allows unauthenticated access if traffic bypasses the SecurityPolicy or the HTTPRoute name drifts after chart upgrades.
> 
> **Overview**
> Adds a new **`netflow`** namespace on atlantis with **ClickHouse** (100Gi), **single-node KRaft Kafka** (20Gi, 1-day buffer), and **Akvorado** (orchestrator, inlet, outlet, console) wired for IPFIX from `border1.den1` through Kafka into ClickHouse, with SNMP enrichment and IPinfo GeoIP sidecar.
> 
> The console is exposed on the tailnet gateway at `akvorado.${CLUSTER_SVCS_DOMAIN}` behind **freckle.id OIDC** via a load-bearing **SecurityPolicy** (`forwardIDToken` + JWT claim-to-`Remote-*` headers); the app itself trusts those headers and has no in-app auth for direct cluster access.
> 
> Flow ingest uses a **hand-written LoadBalancer** (`akvorado-inlet-flows`) with **`externalTrafficPolicy: Local`** and a **pinned** `10.140.250.10` so exporter source IP and SNMP polling stay correct. The **akvorado** Flux Kustomization spells out **`postBuild.substituteFrom`** (including `site-public-ips`) instead of the shared post-build component so public CIDR substitution is not dropped on CRD list replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d65e9da95ad09dc0befd737c2c818a636e060a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->