### PR TITLE
fix(netflow): mount kafka log dir on a subPath

### DIFF
--- a/kubernetes/apps/networking/netflow/kafka/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/kafka/helmrelease.yaml
@@ -121,4 +121,10 @@ spec:
         advancedMounts:
           kafka:
             app:
+              # subPath matters: ceph-block hands us an ext4 volume whose root
+              # contains lost+found, and Kafka refuses to start if its log dir
+              # holds anything that isn't a topic-partition directory
+              # ("'lost+found' is not in the form of topic-partition").
+              # Mounting a subdirectory keeps lost+found out of view.
               - path: /var/lib/kafka/data
+                subPath: data


### PR DESCRIPTION
Kafka crash-looped on first start after #2212:

```
Found directory /var/lib/kafka/data/lost+found, 'lost+found' is not in the form
of topic-partition or topic-partition.uniqueId-delete (if marked for deletion).
Kafka's log directories (and children) should only contain Kafka topic data.
```

`ceph-block` hands us an ext4 volume whose root contains `lost+found`, and Kafka refuses to start if its log dir holds anything that isn't a topic-partition directory. Mounting a subdirectory of the volume keeps `lost+found` out of view — the same `subPath` pattern used elsewhere in the repo.

No data loss: the broker never came up, so there is nothing in the volume worth preserving.

ClickHouse is unaffected — it tolerates `lost+found` at its data root and is already Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Helm mount change for a broker that never successfully started; no auth or data-migration risk.
> 
> **Overview**
> Kafka on the netflow stack was **crash-looping** on first boot because `ceph-block` PVCs are ext4 volumes whose root includes `lost+found`, and Kafka treats anything in `KAFKA_LOG_DIRS` that isn’t a topic-partition directory as fatal.
> 
> The netflow **Kafka** `HelmRelease` now mounts `/var/lib/kafka/data` with **`subPath: data`** (aligned with the persistence `suffix: data`), so the broker only sees a clean subdirectory and not the volume root. Inline comments document why this is required for ceph-block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c57e03e3f8712ec5289dd9b9d18a9ba639ddc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->