### PR TITLE
fix(netflow): point kafka controller quorum at localhost

### DIFF
--- a/kubernetes/apps/networking/netflow/kafka/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/kafka/helmrelease.yaml
@@ -38,7 +38,13 @@ spec:
               # KRaft: this single node is both controller and broker.
               KAFKA_NODE_ID: "1"
               KAFKA_PROCESS_ROLES: controller,broker
-              KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+              # localhost, not the Service name. Controller and broker are the
+              # same JVM here, and the Service is headless — which publishes
+              # only *ready* endpoints, so `kafka:9093` doesn't resolve until
+              # the broker is ready, which it can't be until it reaches the
+              # controller. Upstream's own single-node KRaft config uses
+              # localhost for exactly this reason.
+              KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
               # Listeners. CLIENT is advertised as the Service name, which is
               # how the akvorado inlet and outlet reach it.
               KAFKA_LISTENERS: CLIENT://:9092,CONTROLLER://:9093


### PR DESCRIPTION
Follow-up to #2215. With `lost+found` out of the log dir the broker got further, then failed with:

```
[BrokerLifecycleManager id=1] Shutting down because we were unable to register with the controller quorum.
Connection to node 1 (kafka/10.101.56.244:9093) could not be established. Node may not be available.
```

app-template makes a StatefulSet's primary Service **headless**, and a headless Service publishes only *ready* endpoints. So `kafka:9093` has no DNS answer until the broker is ready — and the broker can't become ready until it registers with the controller. Deadlock on first start.

Controller and broker are the same JVM in this single-node deployment, so pointing the quorum at `localhost` drops the DNS dependency entirely. This is what upstream's own single-node KRaft config (`config/kraft/server.properties`) does.

The advertised CLIENT listener stays on the Service name — by the time akvorado connects, the broker is ready and endpoints are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-env tuning for netflow Kafka startup only; no auth, data model, or client listener changes beyond fixing controller self-registration.
> 
> **Overview**
> Fixes a **first-start deadlock** for the single-node Akvorado Kafka StatefulSet by changing `KAFKA_CONTROLLER_QUORUM_VOTERS` from `1@kafka:9093` to **`1@localhost:9093`**.
> 
> On a headless Service, endpoints only appear once the pod is ready, so the broker could not reach the controller at the Service hostname until it had already registered with the controller. With controller and broker in the same JVM, **localhost** avoids that DNS/readiness cycle. Inline comments document the rationale; **`KAFKA_ADVERTISED_LISTENERS`** stays `CLIENT://kafka:9092` for Akvorado clients after the broker is up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e443417c5a27f78e182cdb047f78755cb6dba30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->