### PR TITLE
fix(netflow): raise akvorado orchestrator memory limit

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
@@ -63,9 +63,14 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 256Mi
+              # The orchestrator is the memory-hungry one despite doing the
+              # least at steady state: it loads the GeoIP databases and the
+              # networks dictionary and pushes them into ClickHouse. 512Mi
+              # got it OOMKilled during that load, which then crash-looped
+              # every other service, since they all fetch config from it.
               limits:
-                memory: 512Mi
+                memory: 2Gi
           # Keeps the IPinfo country/ASN databases fresh in a volume shared
           # with the orchestrator. The token below is the public one upstream
           # ships in docker-compose-ipinfo.yml for the free databases — it is


### PR DESCRIPTION
The orchestrator was OOMKilled (exit 137) at a 512Mi limit while loading the GeoIP databases and networks dictionary into ClickHouse.

Because every other service fetches its configuration from the orchestrator over HTTP, its death took the rest down with it — inlet, outlet and console all crash-looped on `connection refused` against `akvorado-orchestrator:8080`. The schema migration itself completed fine; this is purely the load step.

Raise the limit to 2Gi and the request to 256Mi. The orchestrator does the least work at steady state but has the largest peak, and the blast radius of it dying is the whole pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kubernetes resource tuning only; no application logic or security changes. Slightly higher guaranteed memory on the node for one pod.
> 
> **Overview**
> Raises **Akvorado orchestrator** container memory after OOM at the previous **512Mi** limit during GeoIP/network dictionary load into ClickHouse.
> 
> **Requests** go from **128Mi** to **256Mi**; **limits** from **512Mi** to **2Gi**. Inline comments document that the orchestrator’s peak memory during that load step exceeds steady-state use and that its failure cascades to inlet, outlet, and console because they pull config from `akvorado-orchestrator:8080`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694050b96b8e1f12ee533c55539e2834a18b5285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->