### PR TITLE
fix(netflow): source akvorado OIDC creds from GSM, not 1Password

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
@@ -1,25 +1,30 @@
 ---
-# OIDC client credentials for the Akvorado console. 1Password item `akvorado`
-# must have oidc_client_id and oidc_client_secret fields. Register the client
-# in pocket-id with redirect URI
-# https://akvorado.atlantis.freckle.services/oauth2/callback before deploying.
+# OIDC client credentials for the Akvorado console.
+#
+# The pocket-id client itself is tofu-managed (`oidc_clients.akvorado_atlantis`
+# in the private repo's platform config). tofu pushes a JSON blob with
+# client-id + client-secret into GSM as `<cluster>-<namespace>-<name>`, so
+# `dataFrom.extract` lands both as their own keys with no templating.
+#
+# Nothing to register by hand — a tofu apply creates the client, the secret and
+# the IAM grant together. Cluster-specific because the GSM key is prefixed with
+# the cluster name; the namespace's gcp-sm SecretStore is defined alongside the
+# Flux pointers.
 # yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: akvorado-oidc
 spec:
+  refreshInterval: 1h
   secretStoreRef:
-    kind: ClusterSecretStore
-    name: op-cluster-vault
+    kind: SecretStore
+    name: gcp-sm
   target:
-    template:
-      data:
-        client-id: "{{ .oidc_client_id }}"
-        client-secret: "{{ .oidc_client_secret }}"
+    name: akvorado-oidc
   dataFrom:
     - extract:
-        key: akvorado
+        key: ${CLUSTER_NAME}-netflow-akvorado-oidc
 ---
 # The console has no authentication of its own — it trusts a Remote-User
 # header and assumes something in front established the identity. That makes

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/external-secrets.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/external-secrets.yaml
@@ -1,0 +1,32 @@
+---
+# k8s SA + GCP Secret Manager SecretStore for netflow on atlantis-k8s01.
+# Reads GSM secrets matching the atlantis-k8s01-netflow-* prefix grant, which
+# tofu's `oidc_eso` module creates for every (cluster, namespace) pair that
+# owns an OIDC client. WIF, so no credential is stored here.
+#
+# SA name is `external-secrets-<cluster>` rather than
+# `external-secrets-<namespace>` because that is the convention the tofu
+# module grants against — the same identity also covers CF tokens.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-atlantis-k8s01
+  namespace: netflow
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gcp-sm
+  namespace: netflow
+spec:
+  provider:
+    gcpsm:
+      projectID: freckle-secrets-db8d4f
+      auth:
+        workloadIdentityFederation:
+          audience: //iam.googleapis.com/projects/305363951351/locations/global/workloadIdentityPools/k8s-clusters/providers/atlantis-k8s01
+          serviceAccountRef:
+            name: external-secrets-atlantis-k8s01
+            namespace: netflow
+            audiences:
+              - //iam.googleapis.com/projects/305363951351/locations/global/workloadIdentityPools/k8s-clusters/providers/atlantis-k8s01

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: netflow
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ./external-secrets.yaml
   - ./site-public-ips.yaml
   - ./clickhouse.yaml
   - ./kafka.yaml


### PR DESCRIPTION
Pairs with freckleapps/infra#43.

OIDC clients are tofu-managed with their credentials in GSM — that's the pattern we're migrating onto. This one was written against the older 1Password flow instead, which would have meant registering the pocket-id client by hand and hand-copying its secret.

## Change

- ExternalSecret now reads the namespace's `gcp-sm` SecretStore and the tofu-written key `${CLUSTER_NAME}-netflow-akvorado-oidc`
- Adds the ServiceAccount + SecretStore giving netflow a WIF identity for the `atlantis-k8s01-netflow-*` prefix, matching how observability and janet-mcp do it
- Drops the `target.template` block: the GSM blob already carries `client-id` and `client-secret` as separate keys, so `dataFrom.extract` lands them directly with no renaming

SA is named `external-secrets-<cluster>` rather than `external-secrets-<namespace>` because that's the convention tofu's `oidc_eso` module grants against.

## Ordering

Requires freckleapps/infra#43 to be applied. Until then the ExternalSecret reports `SecretSyncedError` and the console's SecurityPolicy stays `Invalid` — no regression, that is already the state on main today, but it does mean **the console is currently served without authentication** since Envoy Gateway fails open on an invalid policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how load-bearing Akvorado OIDC credentials are sourced and depend on infra#43 and GSM IAM; until sync succeeds the console may remain unauthenticated at the gateway.
> 
> **Overview**
> **Akvorado console OIDC** is switched from the legacy **1Password** `ClusterSecretStore` flow to **GCP Secret Manager**, aligned with tofu-managed pocket-id clients (pairs with infra#43).
> 
> The `akvorado-oidc` **ExternalSecret** now uses the namespace **`gcp-sm` SecretStore**, reads **`${CLUSTER_NAME}-netflow-akvorado-oidc`**, and drops **`target.template`** because the GSM JSON already exposes `client-id` and `client-secret` for direct extract. Comments document that registration is fully tofu-driven.
> 
> For **atlantis-k8s01**, **`external-secrets.yaml`** adds the **`external-secrets-atlantis-k8s01`** ServiceAccount and WIF-backed **`gcp-sm` SecretStore** (same cluster-scoped SA naming as cert-manager, matrix, observability), and **`kustomization.yaml`** includes that resource.
> 
> Until infra#43 lands and the secret syncs, the console’s **SecurityPolicy** stays invalid and Envoy may serve the UI **without OIDC**—same broken state as today on main, not a new regression from this diff alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4729d185b1945f3d9b1ac191db96058f5dcda7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->