### PR TITLE
fix(netflow): drop the akvorado jwt filter, gate only

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -139,6 +139,10 @@ data:
 
     console:
       auth:
+        # These are akvorado's defaults, restated for clarity. Nothing sets
+        # them today: the gateway authenticates but cannot pass identity
+        # through on any released Envoy Gateway (see oidc.yaml), so every
+        # session falls back to the built-in `__default` user.
         headers:
           login: Remote-User
           name: Remote-Name

--- a/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
@@ -28,14 +28,25 @@ spec:
 ---
 # The console has no authentication of its own — it trusts a Remote-User
 # header and assumes something in front established the identity. That makes
-# this policy load-bearing, not defence in depth.
+# this policy load-bearing, not defence in depth: getting past pocket-id is
+# the whole of the access control.
 #
-# Two filters cooperate. Envoy Gateway orders oauth2 (8) before jwt_authn (9),
-# so:
-#   1. `oidc` challenges the browser against pocket-id and, once authenticated,
-#      injects the ID token as `Authorization: Bearer ...`.
-#   2. `jwt` validates that token against pocket-id's JWKS and copies claims
-#      into the headers the console reads.
+# Gate only, no identity. This originally also carried a `jwt` provider with
+# claimToHeaders, so the console would see real usernames — Envoy Gateway
+# orders oauth2 (8) before jwt_authn (9), so the ID token forwarded by
+# `oidc.forwardIDToken` would have been available to it.
+#
+# That does not work on any released Envoy Gateway. `ForwardIDToken` exists in
+# the v1.8.2 API types and passes CRD validation, but nothing under internal/
+# reads it — the field is declared and never implemented, so the policy reports
+# Accepted=True and silently forwards nothing. jwt_authn then rejects every
+# request with "Jwt is missing". Still unimplemented in v1.8.3; the wiring
+# exists only on EG main (internal/gatewayapi/securitypolicy.go).
+#
+# So every authenticated user shares akvorado's built-in `__default` identity
+# and saved filters are shared. Revisit when EG ships ForwardIDToken; the
+# alternative today is an oauth2-proxy extAuth backend, which is what upstream
+# akvorado documents.
 #
 # The targetRef is the bare `akvorado` HTTPRoute: app-template drops the key
 # suffix when a release declares a single route. If that ever becomes
@@ -67,24 +78,3 @@ spec:
       - openid
       - email
       - profile
-    # Hands the ID token to the JWT filter below. Without this the claims
-    # never reach the console and every session would be anonymous.
-    forwardIDToken:
-      header: Authorization
-  jwt:
-    providers:
-      - name: pocket-id
-        issuer: https://freckle.id
-        remoteJWKS:
-          uri: https://freckle.id/.well-known/jwks.json
-        # No `audiences`: the audience of an ID token is the client ID, which
-        # lives in a secret and cannot be templated in here. Issuer and
-        # signature validation against pocket-id's JWKS is the real check, and
-        # the token only ever arrives from the oidc filter above.
-        claimToHeaders:
-          - claim: preferred_username
-            header: Remote-User
-          - claim: name
-            header: Remote-Name
-          - claim: email
-            header: Remote-Email


### PR DESCRIPTION
Logging in succeeded and then every request failed with **"Jwt is missing"**.

## Cause

`oidc.forwardIDToken` is declared in Envoy Gateway's v1.8.2 API types (`api/v1alpha1/oidc_types.go:109`) and passes CRD validation — but **nothing under `internal/` reads it**. The field is declared and never implemented, so the policy reports `Accepted=True` and forwards nothing. `jwt_authn` then finds no token and rejects.

For contrast, `ForwardAccessToken` in the same struct *is* wired: `internal/ir/xds.go:1313` → `internal/gatewayapi/securitypolicy.go:1639`.

Still unimplemented in **v1.8.3**, the current release. The wiring exists only on EG `main` (`ForwardIDTokenHeader` in the IR, read at `internal/gatewayapi/securitypolicy.go:942`), so there is no released version where the original design works.

This is a nasty failure mode: CRD accepts the field, controller accepts the policy, status is green, and it silently does nothing.

## Change

Remove `forwardIDToken` and the `jwt` provider, keep the OIDC gate.

Access control is **unchanged** — pocket-id still guards every request. What's lost is identity: the console can't see who you are, so all sessions share akvorado's built-in `__default` user and saved filters are shared.

## Follow-up

Revisit when EG ships `ForwardIDToken`. The alternative that works today is an oauth2-proxy extAuth backend, which is what upstream akvorado documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and gateway policy comments plus removal of a broken JWT path; OIDC access control at the gateway is unchanged.
> 
> **Overview**
> Fixes Akvorado console login where OIDC succeeded but every subsequent request failed with **"Jwt is missing"**.
> 
> The **SecurityPolicy** no longer uses `oidc.forwardIDToken` or the `jwt` provider that mapped ID-token claims to `Remote-User` / `Remote-Name` / `Remote-Email`. On released Envoy Gateway (through v1.8.3), `ForwardIDToken` is accepted by the CRD but not implemented, so no token reaches `jwt_authn` and the filter rejects all traffic. Pocket-id OIDC at the gateway is unchanged—only per-user identity to the console is lost.
> 
> **Comments** in `oidc.yaml` and the Akvorado **configmap** now document that gate-only auth, shared `__default` sessions, and saved filters until EG ships `ForwardIDToken` (or oauth2-proxy extAuth as upstream documents).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8073d7e8ae26b537f4c58f67b8535989ef2602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->