### PR TITLE
fix(netflow): set default sampling rate so flows are not dropped

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -121,6 +121,14 @@ data:
                 communities:
                   - freckle-public
       core:
+        # ipt_NETFLOW exports unsampled, so it emits no IPFIX sampling-rate
+        # field at all — and akvorado drops every flow it cannot scale
+        # ("sampling rate missing"). 1 means 1-in-1, i.e. take the byte and
+        # packet counts at face value, which is exactly right here.
+        #
+        # If the router is ever switched to sampled export, this MUST change
+        # to match or every count will be wrong by that factor.
+        default-sampling-rate: 1
         exporter-classifiers:
           # SNMP sysName is "border1.den1", so the trailing label is the site.
           - ClassifySiteRegex(Exporter.Name, "\\.([^.]+)$", "$1")


### PR DESCRIPTION
The router is exporting and the whole pipeline is moving, but ClickHouse stayed at 0 rows. The outlet was consuming every Kafka message and discarding it:

```
akvorado_outlet_core_received_flows_total{exporter="10.140.0.68"}                    28510
akvorado_outlet_core_flows_errors_total{error="sampling rate missing", exporter=...}  28510
```

`ipt_NETFLOW` exports **unsampled**, so it emits no IPFIX sampling-rate field at all — and akvorado drops any flow it cannot scale.

Set `outlet.core.default-sampling-rate: 1`. One means 1-in-1: take the byte and packet counts at face value, which is exactly what unsampled export means. Validated with `orchestrator --check --dump`; resolves to `{'::/0': 1}`.

If the router is ever switched to sampled export this **must** change to match, or every count will be wrong by that factor. Noted in the config comment.

## Pipeline state before this fix

Everything upstream of the drop was already healthy, which is what made it a clean diagnosis:

| stage | evidence |
|---|---|
| router exporting | `Export: Total 804 pkts, 14297 flows; Errors 0` |
| inlet receiving | `flow_input_udp_packets_total{exporter="10.140.0.68"} 941` — real router IP, so `externalTrafficPolicy: Local` is working |
| inlet → Kafka | topic `flows-v5` at 1316 messages |
| outlet consuming | consumer group lag ~0 across all 4 partitions |
| outlet → ClickHouse | **0 batches** ← here |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documented outlet config default for unsampled netflow; wrong value would skew metrics but does not touch auth or cluster security paths.
> 
> **Overview**
> **Fixes a silent data loss bug** where the Akvorado outlet consumed Kafka flows but wrote **zero rows** to ClickHouse because every flow was rejected with `sampling rate missing`.
> 
> The border router’s unsampled `ipt_NETFLOW` export omits an IPFIX sampling-rate field; without a fallback, Akvorado drops flows it cannot scale. This adds `outlet.core.default-sampling-rate: 1` (1-in-1, counts at face value) in `akvorado/configmap.yaml`, with a comment that sampled export later must update this value to match the real rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f639f280c8414008fc053c584e0ac509717a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->