### PR TITLE
feat(netflow): validate the akvorado ID token and map real identities

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/oidc.yaml
@@ -78,3 +78,42 @@ spec:
       - openid
       - email
       - profile
+    # Pin the ID token cookie to a fixed name. By default EG appends a random
+    # suffix, which makes it impossible to name in the jwt extractFrom below.
+    cookieNames:
+      idToken: AkvoradoIdToken
+  # Validates the ID token the browser presents as a cookie, and maps its
+  # claims into the headers the console reads.
+  #
+  # This is the cookie route, NOT oidc.forwardIDToken — that field is declared
+  # in the v1.8.2 API and never read by the translator, so it silently forwards
+  # nothing and jwt_authn answers "Jwt is missing". Reading the cookie works
+  # because the browser supplies it on every request after login, so it does
+  # not depend on one filter mutating the request for another.
+  #
+  # Ordering still matters for the FIRST request: oauth2 (filter order 8) runs
+  # before jwt_authn (9), so an unauthenticated request is redirected to
+  # pocket-id rather than rejected for having no token.
+  #
+  # Bonus: envoyproxy/gateway#5414 — EG's OIDC filter does not validate the ID
+  # token at all (no signature or issuer check, contrary to the OIDC spec).
+  # This provider is what actually verifies it for this route.
+  jwt:
+    providers:
+      - name: pocket-id
+        issuer: https://freckle.id
+        remoteJWKS:
+          uri: https://freckle.id/.well-known/jwks.json
+        extractFrom:
+          cookies:
+            - AkvoradoIdToken
+        # No `audiences`: an ID token's aud is the client ID, which lives in a
+        # secret and cannot be templated in here. Issuer + JWKS signature are
+        # the checks that matter, and both now happen.
+        claimToHeaders:
+          - claim: preferred_username
+            header: Remote-User
+          - claim: name
+            header: Remote-Name
+          - claim: email
+            header: Remote-Email


### PR DESCRIPTION
Restores per-user identity in the console, and closes a security gap on the way.

## The mechanism

#2219 removed the `jwt` provider because `oidc.forwardIDToken` is declared in EG's v1.8.2 API and **never read by the translator** — it silently forwards nothing, so `jwt_authn` answered "Jwt is missing".

The cookie route works instead. EG appends a random suffix to the ID token cookie by default, which is why it can't normally be named in a `jwt` `extractFrom` — pinning `oidc.cookieNames.idToken` fixes that.

Crucially this doesn't depend on one filter mutating the request for another, which is precisely where `forwardIDToken` failed: **the browser supplies the cookie** on every request after login.

Ordering still holds for the first request: oauth2 (filter order 8) runs before jwt_authn (9), so an unauthenticated request is redirected to pocket-id rather than rejected for having no token.

## Verified wired in v1.8.2 before writing it

Given how `forwardIDToken` burned us, both halves were checked against the source rather than the API docs:

| field | evidence |
|---|---|
| `oidc.cookieNames.idToken` | `securitypolicy.go:1687` → IR `CookieNameOverrides` → `oidc.go:199` sets `CookieNames.IdToken` |
| `jwt.extractFrom.cookies` | `jwt.go:202` → `jwtProvider.FromCookies` |

Plus schema validation and a server-side dry-run against the live cluster.

## Security

Adding this provider means the ID token is actually **validated** — signature against pocket-id's JWKS, plus issuer. Per envoyproxy/gateway#5414 EG's OIDC filter does none of that today, contrary to the OIDC spec, so this route ends up stronger than EG's default rather than weaker.

`audiences` is omitted: an ID token's `aud` is the client ID, which lives in a secret and can't be templated in.

## Known risk

Envoy encrypts cookie-stored tokens by default (`disableTokenEncryption` defaults to false), which would hand `jwt_authn` ciphertext. Deliberately **not** setting `disableTokenEncryption: true` here — trying the secure configuration first, and only taking the plaintext-cookie trade-off if login actually fails on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes load-bearing access control for the Akvorado console (OIDC + JWT on the gateway SecurityPolicy); misconfiguration could break login or weaken identity mapping, though the intent is to strengthen token validation versus EG’s default OIDC behavior.
> 
> **Overview**
> Restores **per-user identity** in the Akvorado console by re-adding JWT handling on the Envoy Gateway `SecurityPolicy`, using a **cookie-based** ID token path instead of the broken `oidc.forwardIDToken` field (declared in EG v1.8.2 but not implemented in the translator).
> 
> **OIDC cookie pinning:** `oidc.cookieNames.idToken` is set to `AkvoradoIdToken` so the JWT provider can reference a stable cookie name (EG otherwise randomizes the suffix).
> 
> **JWT provider:** Validates the pocket-id ID token from that cookie via issuer + remote JWKS, then maps `preferred_username`, `name`, and `email` to `Remote-User`, `Remote-Name`, and `Remote-Email` for the console. `audiences` is intentionally omitted because the client ID lives in a secret and cannot be templated here.
> 
> Filter ordering keeps oauth2 before jwt_authn so unauthenticated users are redirected to login rather than rejected. This JWT step also becomes the route that **actually verifies** the ID token (signature/issuer), addressing EG OIDC’s lack of ID token validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d8d5013b233cf896e9b6c3fa91893db5316d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->