### PR TITLE
docs(netflow): correct the akvorado auth header comment

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -147,10 +147,11 @@ data:
 
     console:
       auth:
-        # These are akvorado's defaults, restated for clarity. Nothing sets
-        # them today: the gateway authenticates but cannot pass identity
-        # through on any released Envoy Gateway (see oidc.yaml), so every
-        # session falls back to the built-in `__default` user.
+        # These are akvorado's defaults, restated because they are load-bearing:
+        # the gateway's jwt provider maps ID token claims into exactly these
+        # header names (see oidc.yaml), which is how the console learns who you
+        # are. Renaming one here without renaming the matching claimToHeaders
+        # entry silently drops that field back to the default identity.
         headers:
           login: Remote-User
           name: Remote-Name


### PR DESCRIPTION
The comment claimed nothing set these headers and every session fell back to `__default`. That was true for about an hour; identity now works via the ID token cookie (#2221).

They are load-bearing: the gateway's jwt provider maps claims into exactly these header names, so renaming one here without renaming the matching `claimToHeaders` entry silently drops that field back to the default identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a ConfigMap comment; no runtime or security behavior is modified.
> 
> **Overview**
> Updates **comment-only** documentation on the Akvorado console `auth.headers` block in `configmap.yaml`—no config values change.
> 
> The old note said nothing populated `Remote-User` / `Remote-Name` / `Remote-Email` and sessions always used the built-in `__default` user. That is replaced with an explanation that these names are **load-bearing**: Envoy Gateway’s JWT provider in `oidc.yaml` maps ID token claims via `claimToHeaders` into exactly these headers, and the console uses them for identity. The comment warns that renaming a header here without the matching `claimToHeaders` entry would silently revert that field to the default identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59dee74f6978cf6f78adec8647ec53623624cf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->