### PR TITLE
feat(netflow): give each site its own ASN, and drop upstream names

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -42,12 +42,14 @@ data:
     clickhouse:
       orchestrator-url: http://akvorado-orchestrator:8080
       prometheus-endpoint: /metrics
-      # Names for AS numbers, overriding the built-in list. 64610 is
-      # border1-den1's system-as; we reuse it below as "our" AS across both
-      # sites so all Freckle-owned public space aggregates under one entry,
-      # with the `site` attribute distinguishing den1 from btx1.
+      # Names for AS numbers, overriding the built-in list. A private ASN per
+      # site, not one shared "Freckle" AS: the Src/Dst AS breakdown is the view
+      # that actually gets used, so the sites need to be distinguishable there.
+      # SrcNetSite carries the same information but only after drilling in.
+      # 64610 matches border1-den1's system-as.
       asns:
-        64610: Freckle
+        64600: Freckle - btx1
+        64610: Freckle - den1
       # Names our own prefixes so flows involving them are labelled rather
       # than lumped in with the internet. Roles are a first pass and cheap to
       # refine once we see how the console groups things.
@@ -76,12 +78,12 @@ data:
         # they stay out of this public repo, same as the cilium CIDR groups.
         #
         # `asn` overrides what GeoIP reports. Our public space is announced by
-        # the upstreams that assigned it, so IPinfo attributes it to them —
-        # den1's block resolved to AS30475 (the provider), which buried our own
-        # DMZ egress in with third-party traffic in every top-AS view. Pinning
-        # it to 64610 attributes it to us instead. This makes the console
-        # disagree with real BGP data on purpose; cross-check against a looking
-        # glass, not against this.
+        # the upstreams that assigned it, so IPinfo attributes it to them and
+        # our own DMZ egress gets buried in with third-party traffic in every
+        # top-AS view. Pinning each block to its site's private ASN attributes
+        # it to us instead. This makes the console disagree with real BGP data
+        # on purpose; cross-check attribution against a looking glass, not
+        # against this.
         ${SITE_ATLANTIS_PUBLIC_V4_GW}/32:
           name: den1-public
           role: dmz
@@ -108,19 +110,19 @@ data:
           role: dmz
           site: btx1
           tenant: freckle
-          asn: 64610
+          asn: 64600
         ${SITE_FAIRY_PUBLIC_V4_BLOCK}:
           name: btx1-public
           role: dmz
           site: btx1
           tenant: freckle
-          asn: 64610
+          asn: 64600
         ${SITE_FAIRY_PUBLIC_V6_BLOCK}:
           name: btx1-public
           role: dmz
           site: btx1
           tenant: freckle
-          asn: 64610
+          asn: 64600
 
     inlet:
       flow:
@@ -178,10 +180,13 @@ data:
           - ClassifyRole("edge")
           - ClassifyTenant("freckle")
         interface-classifiers:
-          # Upstream's default rule, which already fits our descriptions:
-          # eth0 is "Transit: Summit Hosting" -> connectivity=transit,
-          # provider=Summit, boundary=external. The spine links ("spine1.den1",
-          # "spine2.den1") fall through to internal.
+          # Upstream's default rule, unmodified — it already fits how our
+          # interface descriptions are written. A description of the form
+          # "<Type>: <Provider> ..." yields connectivity=<type>,
+          # provider=<first word after the colon>, boundary=external. Anything
+          # not matching that shape (the spine links) falls through to
+          # internal. Renaming an interface description on the router will
+          # silently reclassify its traffic.
           - |
             ClassifyConnectivityRegex(Interface.Description, "^(?i)(transit|pni|ppni|ix):? ", "$1") &&
             ClassifyProviderRegex(Interface.Description, "^\\S+?\\s(\\S+)", "$1") &&


### PR DESCRIPTION
## Per-site ASNs

A single shared ASN for all our public space was the wrong call. The **Src/Dst AS breakdown is the view that actually gets used**, so the sites need to be distinguishable there — `SrcNetSite` carries the same information but only after drilling into a second view.

Split into a private ASN per site, named so the site shows up in the chart legend directly:

| ASN | Name |
|---|---|
| 64600 | Freckle - btx1 |
| 64610 | Freckle - den1 |

64610 matches `border1-den1`'s `system-as`.

## Comment scrub

Removes our upstreams' names from the comments.

The interface-classifier comment now describes the description *shape* it matches rather than quoting a live interface description. That's more useful anyway — it says what to preserve when renaming an interface, instead of just naming one example.

## Verified

`orchestrator --check --dump` against the real 2.4.1 image with values substituted from the live secret: both ASN names present, 3 prefixes mapped to each site's ASN, no cross-contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Akvorado enrichment and documentation; no runtime code paths or security changes, though console AS attribution will shift for btx1 public traffic after deploy.
> 
> **Overview**
> **Akvorado** netflow attribution now uses **two private ASNs** instead of one shared label: **64600** (`Freckle - btx1`) and **64610** (`Freckle - den1`), so **Src/Dst AS** charts can separate sites without drilling into `SrcNetSite`. **btx1** public prefix overrides move from **64610** to **64600**; **den1** stays on **64610**.
> 
> Comments are updated to explain the per-site ASN rationale, describe per-site public-block pinning without naming upstreams, and document the interface-description classifier **shape** (and that renames can silently change connectivity classification) instead of quoting live router descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c1fe7a8472714033a1aab5ad4efd55afabcdd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->