### PR TITLE
feat(netflow): tag internal ranges with the site ASN too

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -53,27 +53,37 @@ data:
       # Names our own prefixes so flows involving them are labelled rather
       # than lumped in with the internet. Roles are a first pass and cheap to
       # refine once we see how the console groups things.
+      #
+      # The RFC1918 ranges carry an `asn` too. They have no real ASN — nothing
+      # would ever populate one — so without it every internal source lands in
+      # the AS breakdown as "0: ???", including the largest talkers. Tagging
+      # them with the site's private ASN makes that view usable for internal
+      # traffic instead of just for the public blocks.
       networks:
         10.140.0.0/16:
           name: den1-lan
           role: internal
           site: den1
           tenant: freckle
+          asn: 64610
         172.20.0.0/20:
           name: den1-mgmt
           role: management
           site: den1
           tenant: freckle
+          asn: 64610
         172.25.0.0/20:
           name: den1-infra
           role: infrastructure
           site: den1
           tenant: freckle
+          asn: 64610
         172.26.0.0/20:
           name: den1-infra
           role: infrastructure
           site: den1
           tenant: freckle
+          asn: 64610
         # Public blocks come from the site-public-ips secret via postBuild so
         # they stay out of this public repo, same as the cilium CIDR groups.
         #


### PR DESCRIPTION
Only the public blocks carried an `asn`, on the reasoning that RFC1918 has no real AS and `SrcNetName` already identified it.

That reasoning doesn't survive contact with the AS breakdown. Nothing ever populates an AS for private space, so every internal source rendered as **`0: ???`** — including the single largest talker on the link, a site-to-site transfer out of `den1-infra` at 84 GB.

Tag the four den1 RFC1918 ranges with 64610 so that view is usable for internal traffic and not just for the public blocks. It's the same deliberate fiction already applied to the public prefixes, for the same reason.

btx1's internal ranges aren't added — they don't appear in den1 flows, since site-to-site traffic is seen against btx1's public addresses.

## Verified

`orchestrator --check --dump` against the real 2.4.1 image: 10 networks, **0 without an ASN**, 7 mapped to den1's and 3 to btx1's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Netflow console labeling only; no routing, auth, or data-path changes.
> 
> **Overview**
> Adds **`asn: 64610`** to all four den1 RFC1918 **`networks`** entries in the Akvorado config (`10.140.0.0/16`, `172.20.0.0/20`, `172.25.0.0/20`, `172.26.0.0/20`), matching the deliberate site-ASN pinning already used on public prefixes.
> 
> Without that field, internal sources show up in the Src/Dst AS breakdown as **`0: ???`** because private space never gets a real ASN from enrichment. The new comments explain that tagging internal ranges with the site private ASN makes that view usable for on-site traffic, not only for public blocks.
> 
> No btx1 internal ranges are added in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fa7e960af8299494d8c3351e3be5ba7c593810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->