### PR TITLE
fix(netflow): persist the GeoIP databases on an RWX volume

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
@@ -226,10 +226,36 @@ spec:
               - path: /etc/akvorado/akvorado.yaml
                 subPath: akvorado.yaml
                 readOnly: true
-      # Shared between the updater and the orchestrator. Not persisted: the
-      # databases are re-downloaded on start and are not our data.
+      # Shared between the updater and the orchestrator. Persisted, despite
+      # being re-downloadable third-party data: on an emptyDir every restart
+      # discarded the databases and forced a fresh download, and the token
+      # above is upstream's *shared public* one. Six config changes in a day
+      # was enough to earn an HTTP 429, after which the updater sleeps for
+      # UPDATE_FREQUENCY (48h) before retrying — leaving every external IP
+      # resolving to AS 0 in the meantime.
+      #
+      # With a volume the updater finds the files on start, compares checksums
+      # and skips the download entirely, so restarts stop costing a fetch.
+      #
+      # RWX on ceph-filesystem rather than RWO on ceph-block, so the volume is
+      # never the thing that constrains the deployment. app-template defaults
+      # Deployments to Recreate, so RWO would work today — but it would quietly
+      # block both switching to RollingUpdate and running a second
+      # orchestrator, which upstream supports via `clickhouse.skip-migrations`
+      # ("the schema is managed by another orchestrator"). The dataset is ~50MB
+      # and read-mostly, so RWX costs nothing here.
+      #
+      # Scaling out would need the updater moved out of this pod first: each
+      # replica runs its own sidecar, so N replicas means N writers racing on
+      # the same files and N downloads against a shared, rate-limited token.
       geoip:
-        type: emptyDir
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: ceph-filesystem
+        accessMode: ReadWriteMany
+        size: 1Gi
+        retain: true
+        suffix: geoip
         advancedMounts:
           orchestrator:
             app:


### PR DESCRIPTION
External IPs were intermittently resolving to **AS 0** instead of their real ASN — the same address showing as `34305: Base IP` in one row and `0: ???` in another.

## Cause

The GeoIP volume was an `emptyDir`, on the reasoning that the databases are re-downloadable third-party data. That ignored the *cost* of re-downloading. Every orchestrator restart discarded them, Reloader restarts the orchestrator on every config change, and the token is upstream's **shared public** one:

```
Failed to download country.mmdb database (HTTP error 429).
Failed to download asn.mmdb database (HTTP error 429).
```

Six config changes in a day was enough to get rate-limited. Worse, the updater sleeps `UPDATE_FREQUENCY` (48h) after a failure before retrying — so a rate-limit costs two days of missing enrichment, not a few minutes.

## Fix

Persist it. On a volume the updater finds the files, compares checksums and skips the download entirely, so restarts stop costing a fetch.

**RWX on `ceph-filesystem`** rather than RWO on ceph-block, so the volume never becomes the constraint. app-template defaults Deployments to `Recreate` (`_valuesToObject.tpl`), so RWO would work today — but it would quietly block both switching to RollingUpdate and running a second orchestrator, which upstream supports via `clickhouse.skip-migrations` ("the schema is managed by another orchestrator"). The dataset is ~50MB and read-mostly, so RWX costs nothing.

Scaling out would need the updater moved out of the pod first — each replica carries its own sidecar, so N replicas means N writers racing on the same files and N downloads against a rate-limited token. Noted inline.

## Note

We are currently rate-limited with no databases at all, so external ASN enrichment is broken until one download succeeds. Once it does, the volume keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only persistence change for third-party GeoIP data; no application logic or auth changes, with mounts unchanged aside from backing storage.
> 
> **Overview**
> Replaces the Akvorado **GeoIP** `emptyDir` with a **1Gi** `persistentVolumeClaim` on `ceph-filesystem` (`ReadWriteMany`, `retain: true`), so IPinfo country/ASN files survive orchestrator restarts and Reloader-driven config rollouts.
> 
> The inline comment documents why: each restart on `emptyDir` forced a re-download against upstream’s shared public token, which led to HTTP **429** and up to **48h** without ASN enrichment (AS 0). With persistence, the geoip sidecar can checksum existing files and skip fetches. **RWX** is chosen so future RollingUpdate or a second orchestrator replica is not blocked by RWO attachment limits; scaling replicas still needs the updater sidecar decoupled first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69823b7bd32c427668fcb689a1c16092b1df26d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->