### PR TITLE
feat(netflow): switch GeoIP to MaxMind GeoLite2, and stop making it optional

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/configmap.yaml
@@ -29,11 +29,26 @@ data:
       # Loaded by the orchestrator, which pushes the data into ClickHouse as
       # dictionaries; the outlet never reads these files. Optional so a failed
       # database download degrades enrichment instead of blocking startup.
-      optional: true
+      # Deliberately NOT optional. With `optional: true` a missing database is
+      # silently skipped (geoip/iter.go) and the component just runs without
+      # it — which is how we spent a stretch with every external address
+      # resolving to AS 0 while every health signal stayed green.
+      #
+      # false makes it a hard failure: the orchestrator refuses to start if a
+      # database is missing (geoip/root.go). The cost is a cold-start
+      # dependency — on an empty volume it crash-loops until the updater
+      # sidecar finishes its first download — but it self-heals, and a loud
+      # failure beats silently serving flows with no enrichment.
+      #
+      # Files appearing later are picked up automatically once running: the
+      # component watches the directory with fsnotify.
+      optional: false
       asn-database:
-        - /usr/share/GeoIP/asn.mmdb
+        - /usr/share/GeoIP/GeoLite2-ASN.mmdb
+      # City rather than Country: it carries country + subdivision + city, so
+      # SrcGeoCity/SrcGeoState get populated instead of sitting empty.
       geo-database:
-        - /usr/share/GeoIP/country.mmdb
+        - /usr/share/GeoIP/GeoLite2-City.mmdb
 
     clickhousedb:
       servers:

--- a/kubernetes/apps/networking/netflow/akvorado/externalsecret-maxmind.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/externalsecret-maxmind.yaml
@@ -1,0 +1,30 @@
+---
+# MaxMind GeoLite2 credentials for the geoipupdate sidecar.
+#
+# Unlike the OIDC client, this is not tofu-generated — it's an account
+# credential you hold, so it's seeded into GSM by hand the same way
+# `tofu-pocketid-api-token` is:
+#
+#   printf '{"account-id":"%s","license-key":"%s"}' "$ID" "$KEY" \
+#     | gcloud secrets create ${CLUSTER_NAME}-netflow-maxmind \
+#         --project=freckle-secrets-db8d4f --data-file=-
+#
+# No IAM change needed: the namespace's ESO identity is already granted the
+# `<cluster>-netflow-*` prefix by tofu's oidc_eso module, and this key sits
+# under it. Stored as a JSON blob so dataFrom.extract lands both fields as
+# their own keys with no templating.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: akvorado-maxmind
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    name: akvorado-maxmind
+  dataFrom:
+    - extract:
+        key: ${CLUSTER_NAME}-netflow-maxmind

--- a/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
@@ -71,18 +71,37 @@ spec:
               # every other service, since they all fetch config from it.
               limits:
                 memory: 2Gi
-          # Keeps the IPinfo country/ASN databases fresh in a volume shared
-          # with the orchestrator. The token below is the public one upstream
-          # ships in docker-compose-ipinfo.yml for the free databases — it is
-          # not a credential of ours.
+          # Keeps the GeoLite2 databases fresh in a volume shared with the
+          # orchestrator.
+          #
+          # MaxMind rather than the IPinfo free tier, for two reasons. Ours is
+          # a real licensed account, so we get our own quota — the IPinfo path
+          # used a token upstream ships publicly in docker-compose-ipinfo.yml,
+          # and enough restarts in one day earned an HTTP 429 that silently
+          # zeroed AS enrichment. And GeoLite2-City carries city + subdivision,
+          # where IPinfo's free tier is country-only: SrcGeoCity/SrcGeoState
+          # exist in the schema and were entirely empty.
+          #
+          # ASN accuracy was not the reason — GeoLite2-ASN and IPinfo's ASN
+          # data are both fine for this.
           geoip:
             image:
-              repository: quay.io/akvorado/ipinfo-geoipupdate
-              tag: latest@sha256:8e0c29dd857afc62969bbefefd768809780829767446c5ddac7f25b88957d476
+              repository: ghcr.io/maxmind/geoipupdate
+              tag: v7@sha256:45e15eb310528fd308c5c0abee9a8e6d580f1e2b1251e960dec2863dc7f0102f
             env:
-              IPINFO_TOKEN: a2632ea59736c7
-              IPINFO_DATABASES: country asn
-              UPDATE_FREQUENCY: 48h
+              GEOIPUPDATE_EDITION_IDS: GeoLite2-ASN GeoLite2-City
+              # Hours, not a duration string like the IPinfo updater took.
+              GEOIPUPDATE_FREQUENCY: "48"
+              GEOIPUPDATE_ACCOUNT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: akvorado-maxmind
+                    key: account-id
+              GEOIPUPDATE_LICENSE_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: akvorado-maxmind
+                    key: license-key
             securityContext: *containerSecurity
             resources:
               requests:
@@ -261,8 +280,10 @@ spec:
             app:
               - path: /usr/share/GeoIP
                 readOnly: true
+            # Same path for the updater — geoipupdate's default DB dir, and
+            # what the orchestrator reads. The IPinfo updater used /data.
             geoip:
-              - path: /data
+              - path: /usr/share/GeoIP
       # Every container has a read-only root filesystem, so anything that
       # writes needs an explicit volume.
       outlet-state:

--- a/kubernetes/apps/networking/netflow/akvorado/kustomization.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap.yaml
+  - externalsecret-maxmind.yaml
   - helmrelease.yaml
   - service-inlet.yaml
   - oidc.yaml


### PR DESCRIPTION
## Why MaxMind

Not ASN accuracy — GeoLite2-ASN and IPinfo's ASN data are both fine for this.

1. **Our own quota.** The IPinfo path relied on a token upstream ships *publicly* in `docker-compose-ipinfo.yml`. Enough orchestrator restarts in one day earned an HTTP 429 that silently zeroed AS enrichment for every external address.
2. **City-level geo.** `GeoLite2-City` carries country + subdivision + city, where IPinfo's free tier is country-only. `SrcGeoCity`/`SrcGeoState` exist in the schema and were entirely empty — **0 of 36,646 rows**.

## `optional: false`

The more important half of this change.

With `optional: true`, a missing database is silently skipped (`geoip/iter.go`) and the component just runs without it. That is exactly how the 429 went unnoticed: pods healthy, Kustomizations Ready, flows landing — and no enrichment.

`false` makes it a hard failure; the orchestrator refuses to start (`geoip/root.go:110`). The cost is a cold-start dependency: on an empty volume it crash-loops until the sidecar's first download completes. It self-heals, and failing loudly beats serving flows with no enrichment.

Files appearing later are still picked up automatically once running — the component watches the directory with fsnotify.

**The volume was pre-seeded with both GeoLite2 databases before merging**, so this cutover has its files already and shouldn't crash-loop at all.

## Credentials

Seeded into GSM by hand, like `tofu-pocketid-api-token`, since this is an account credential rather than something tofu generates. No IAM change needed — the namespace's ESO identity already holds the `<cluster>-netflow-*` prefix from tofu's `oidc_eso` module.

## Gotchas found while writing this

- `GEOIPUPDATE_FREQUENCY` is **bare hours** (`48`), not a duration string like the IPinfo updater's `48h`. Quoted so YAML doesn't coerce it.
- geoipupdate's DB dir is `/usr/share/GeoIP`, not `/data` — both containers now mount the volume at the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes netflow enrichment and orchestrator startup semantics (hard fail / possible crash-loop until GeoIP files exist), plus a new secret dependency for MaxMind downloads.
> 
> **Overview**
> Replaces the Akvorado **IPinfo** geo sidecar with **MaxMind `geoipupdate`**, pulling **GeoLite2-ASN** and **GeoLite2-City** into `/usr/share/GeoIP` (shared RWX volume). Config now points at `GeoLite2-ASN.mmdb` and `GeoLite2-City.mmdb` so city/state enrichment can populate, and credentials come from a new **ExternalSecret** (`akvorado-maxmind`) synced from GSM JSON (`account-id` / `license-key`).
> 
> The bigger behavioral change is **`geoip.optional: false`**: the orchestrator will **refuse to start** if databases are missing instead of running with silent AS 0 enrichment. Expect a **cold-start coupling** to the sidecar’s first download unless the volume is already seeded.
> 
> Helm updates sidecar env (`GEOIPUPDATE_*`, 48-hour frequency as a quoted string) and aligns the updater mount with the orchestrator read path (was `/data` for IPinfo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c7c570a7d7e389e5ac56ec13e6eb93e8cd7a49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->