### PR TITLE
fix(netflow): raise orchestrator memory for GeoLite2-City, add GOMEMLIMIT

### DIFF
--- a/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/helmrelease.yaml
@@ -44,6 +44,13 @@ spec:
             args:
               - orchestrator
               - /etc/akvorado/akvorado.yaml
+            env:
+              # Go does not know about the cgroup limit and will happily grow
+              # until the kernel kills it. Setting a soft limit below the hard
+              # one makes the GC work harder as it approaches, turning an
+              # OOMKill into a slower reconcile. Keep it comfortably under
+              # limits.memory below — this bounds heap, not total RSS.
+              GOMEMLIMIT: 3GiB
             probes: &probes
               liveness: &probe
                 enabled: true
@@ -66,11 +73,17 @@ spec:
                 memory: 256Mi
               # The orchestrator is the memory-hungry one despite doing the
               # least at steady state: it loads the GeoIP databases and the
-              # networks dictionary and pushes them into ClickHouse. 512Mi
-              # got it OOMKilled during that load, which then crash-looped
-              # every other service, since they all fetch config from it.
+              # networks dictionary and pushes them into ClickHouse. 512Mi got
+              # it OOMKilled during that load, which crash-looped every other
+              # service, since they all fetch config from it.
+              #
+              # 2Gi was then enough for IPinfo's 10MB country file but not for
+              # GeoLite2-City at 63MB — it OOMKilled once on the switch and
+              # settled at 2001Mi against a 2048Mi limit, i.e. 98% and one GC
+              # cycle from the next kill. The peak recurs on every start,
+              # because the whole database is walked to build the dictionary.
               limits:
-                memory: 2Gi
+                memory: 4Gi
           # Keeps the GeoLite2 databases fresh in a volume shared with the
           # orchestrator.
           #


### PR DESCRIPTION
Switching to GeoLite2-City OOMKilled the orchestrator once on cutover, then left it running at **2001Mi against a 2048Mi limit** — 98%, which is one GC cycle from the next kill rather than actually stable.

The peak recurs on **every start**, because the whole database is walked to build the ClickHouse dictionary, and City is 63 MB against the 10 MB country file it replaced.

## Change

- Limit 2Gi → **4Gi**
- **`GOMEMLIMIT: 3GiB`**

The second matters as much as the first. Go doesn't know about the cgroup limit, so its GC has no reason to collect harder as it approaches — the kernel kills the process instead of the runtime reclaiming. A soft limit below the hard one turns an OOMKill into a slower reconcile.

Requests stay at 256Mi; this is a ceiling, not a reservation, on a 64 GB node.

## Context

Third memory adjustment on this container, each from a real observed kill rather than guesswork: 512Mi → 2Gi (initial GeoIP + dictionary load), 2Gi → 4Gi (GeoLite2-City). Worth remembering that this component's cost scales with database size, not with flow volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-container resource tuning in netflow with no auth or data-model changes; slightly higher memory ceiling on one pod.
> 
> **Overview**
> Raises the Akvorado **orchestrator** memory ceiling after GeoLite2-City (63MB vs ~10MB country) caused OOM at startup and left the pod near a 2Gi limit on every dictionary rebuild.
> 
> **Memory limit** goes from **2Gi → 4Gi**; **requests stay 256Mi**. Inline comments document the prior 512Mi → 2Gi → 4Gi progression and why startup peaks repeat when the full GeoIP DB is walked for ClickHouse.
> 
> Adds **`GOMEMLIMIT: 3GiB`** so the Go runtime GC ramps before the cgroup hard limit, reducing abrupt OOMKills (orchestrator failure still cascades because other Akvorado services pull config from it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0921c9cc08c2628f69e7613762f33edd65f945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->