### PR TITLE
fix(ci): unbreak Image Pull and Schema Validation on main

### DIFF
--- a/.github/workflows/image-pull-extract-pull.yaml
+++ b/.github/workflows/image-pull-extract-pull.yaml
@@ -55,26 +55,64 @@ jobs:
           base: ""
           version: "0.4.12"
 
-      # --allow-missing-secrets: the janet OCIRepository authenticates with the
-      # `ghcr-pull` dockerconfigjson, which is materialized by a
-      # ClusterExternalSecret (namespace-label gated), not by an in-repo
+      # --allow-missing-secrets: the janet/hedgehog OCIRepositories authenticate
+      # with the `ghcr-pull` dockerconfigjson, materialized by a
+      # ClusterExternalSecret (namespace-label gated) rather than an in-repo
       # ExternalSecret. flate's producer-aware auto-skip only recognizes
-      # ExternalSecret/SealedSecret with a static target name, so it has no
-      # evidence the Secret exists live, fails loud, and then resolves that
-      # Kustomization's `path: ./flux` against this checkout — taking 52
-      # dependent Kustomizations down with it. The flag soft-skips source auth
-      # Secrets that only materialize in-cluster. Trade-off: it is blanket, so a
-      # genuinely mistyped secretRef is skipped rather than caught here; cert
-      # and proxy secretRefs still fail loud. Images inside the private janet
-      # bundle are consequently not pre-pulled — they are owned by the app repo,
-      # not this one.
+      # ExternalSecret/SealedSecret with a static target name, so without this
+      # it fails loud on `secret janet/ghcr-pull not found`. Trade-off: the flag
+      # is blanket, so a genuinely mistyped source secretRef is skipped rather
+      # than caught here; cert and proxy secretRefs still fail loud. Images
+      # inside those private bundles are consequently not pre-pulled — they are
+      # owned by the app repos, not this one.
+      #
+      # The exit-code handling below is deliberate. flate exits non-zero both
+      # for genuine render failures AND when Kustomizations are merely "blocked
+      # by failed/missing dependencies". Nearly every KS here substitutes from
+      # the `k8s-cluster-info` ConfigMap, which exists in-repo only in
+      # `default` — Reflector replicates it to every namespace at runtime.
+      # flate models a non-optional substituteFrom ConfigMap as a hard
+      # dependency and has no Reflector awareness, so those KSs always block
+      # offline. Making them `optional: true` would silence this, but it would
+      # also downgrade a live-cluster guard: a genuinely absent ConfigMap would
+      # then render with unsubstituted vars instead of failing loudly. We keep
+      # the production semantics and instead gate on the failure count only.
+      #
+      # Consequence, stated plainly: images reachable only through a blocked
+      # Kustomization are NOT enumerated, so they are not pre-pulled. The
+      # render gate keeps its full value; the pre-pull is best-effort. The
+      # summary below reports the shortfall rather than hiding it.
       - name: Gather Images
         run: |
+          rc=0
           flate get images \
             --path kubernetes/clusters/${{ inputs.cluster }}/flux \
             --allow-missing-secrets \
             --output json \
-            --no-progress > images.json
+            --no-progress > images.json 2> flate.err || rc=$?
+
+          cat flate.err
+
+          if [ "${rc}" -ne 0 ]; then
+            # Fail closed: an empty capture means flate died for some reason
+            # other than a reconcile summary (bad flag, download failure, ...).
+            failures=$(grep -oE 'reconcile completed with [0-9]+ failure' flate.err \
+              | grep -oE '[0-9]+' | head -1)
+            if [ -z "${failures}" ] || [ "${failures}" -ne 0 ]; then
+              echo "::error::flate reported render failures for ${{ inputs.cluster }}"
+              exit 1
+            fi
+            blocked=$(grep -oE '\(\+[0-9]+ blocked' flate.err | grep -oE '[0-9]+' | head -1)
+            note="${blocked:-an unknown number of} Kustomizations blocked on runtime-only"
+            note="${note} dependencies (Reflector-replicated k8s-cluster-info);"
+            note="${note} their images are not pre-pulled"
+            echo "::warning::${{ inputs.cluster }} (${{ matrix.branch }}): 0 render failures, ${note}"
+            echo "> ⚠️ ${note}" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Downstream jobs jq over this — a truncated/invalid file must not
+          # silently become an empty diff.
+          jq -e 'type == "array"' images.json > /dev/null
 
       - name: Extract Images
         id: extract

--- a/.github/workflows/image-pull-extract-pull.yaml
+++ b/.github/workflows/image-pull-extract-pull.yaml
@@ -38,10 +38,10 @@ jobs:
       # flate, not flux-local: the latter is deprecated and sunsetted, and it
       # broke here anyway — it followed the infra-private GitRepository it
       # cannot fetch, resolved that Kustomization's path against THIS checkout,
-      # and collapsed every Namespace onto flux-system. flate auto-skips a
-      # source whose auth Secret is declared by an in-repo ExternalSecret.
+      # and collapsed every Namespace onto flux-system.
       # Output is the same flat JSON array of image refs, so the diff below is
       # unchanged.
+      #
       # base: "" is load-bearing. The action defaults base to the repo's
       # default branch, which puts flate in changed-only mode — wrong twice
       # over here. This job wants the FULL image list from each side so the
@@ -55,10 +55,24 @@ jobs:
           base: ""
           version: "0.4.12"
 
+      # --allow-missing-secrets: the janet OCIRepository authenticates with the
+      # `ghcr-pull` dockerconfigjson, which is materialized by a
+      # ClusterExternalSecret (namespace-label gated), not by an in-repo
+      # ExternalSecret. flate's producer-aware auto-skip only recognizes
+      # ExternalSecret/SealedSecret with a static target name, so it has no
+      # evidence the Secret exists live, fails loud, and then resolves that
+      # Kustomization's `path: ./flux` against this checkout — taking 52
+      # dependent Kustomizations down with it. The flag soft-skips source auth
+      # Secrets that only materialize in-cluster. Trade-off: it is blanket, so a
+      # genuinely mistyped secretRef is skipped rather than caught here; cert
+      # and proxy secretRefs still fail loud. Images inside the private janet
+      # bundle are consequently not pre-pulled — they are owned by the app repo,
+      # not this one.
       - name: Gather Images
         run: |
           flate get images \
             --path kubernetes/clusters/${{ inputs.cluster }}/flux \
+            --allow-missing-secrets \
             --output json \
             --no-progress > images.json
 

--- a/.github/workflows/image-pull-extract-pull.yaml
+++ b/.github/workflows/image-pull-extract-pull.yaml
@@ -42,9 +42,17 @@ jobs:
       # source whose auth Secret is declared by an in-repo ExternalSecret.
       # Output is the same flat JSON array of image refs, so the diff below is
       # unchanged.
+      # base: "" is load-bearing. The action defaults base to the repo's
+      # default branch, which puts flate in changed-only mode — wrong twice
+      # over here. This job wants the FULL image list from each side so the
+      # diff job below can compute `pull - default`, and on the `pull` leg
+      # actions/checkout lands a shallow detached PR ref where neither `main`
+      # nor `origin/main` exists, so flate hard-errors resolving the base.
+      # Empty base restores `get`'s default full-tree behavior.
       - name: Setup flate
         uses: home-operations/flate/action@main
         with:
+          base: ""
           version: "0.4.12"
 
       - name: Gather Images

--- a/kubernetes/apps/hedgehog/platform/ocirepository.yaml
+++ b/kubernetes/apps/hedgehog/platform/ocirepository.yaml
@@ -12,6 +12,17 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: hedgehog
+  # Explicit namespace, deviating from the usual "no namespace: under
+  # kubernetes/apps/" rule, because offline renderers resolve a Kustomization's
+  # sourceRef during a STATIC discovery pass that runs before this platform
+  # KS's targetNamespace is applied. Without it the hedgehog/hedgehog sourceRef
+  # matches nothing and gets aliased to the infra checkout root, so `path: ./`
+  # is resolved against this repo and the renderer tries to parse every
+  # top-level file (.markdownlint.yaml et al) as a Kubernetes resource. Live
+  # Flux is unaffected: the platform KS already pins targetNamespace to this
+  # same namespace. Same fix as
+  # kubernetes/apps/inference/janet/platform/ocirepository.yaml.
+  namespace: hedgehog
 spec:
   interval: 5m
   url: oci://ghcr.io/freckleapps/hedgehog-manifests

--- a/kubernetes/apps/inference/janet/platform/ocirepository.yaml
+++ b/kubernetes/apps/inference/janet/platform/ocirepository.yaml
@@ -15,6 +15,18 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: janet
+  # Explicit namespace, deviating from the usual "no namespace: under
+  # kubernetes/apps/" rule, because offline renderers resolve a Kustomization's
+  # sourceRef during a STATIC discovery pass that runs before janet-platform's
+  # targetNamespace is applied. Without it the janet/janet sourceRef matches
+  # nothing, gets aliased to the infra checkout root, and `path: ./flux` is
+  # resolved against this repo (which has no top-level flux/ dir), failing the
+  # bootstrap KS and everything downstream of it. Live Flux is unaffected:
+  # janet-platform already pins targetNamespace to this same namespace. Safe
+  # because this dir is referenced by exactly one pointer
+  # (clusters/fairy-k8s01/apps/janet/platform.yaml) and is janet-specific by
+  # construction — see the kustomization.yaml notes on why it can't be shared.
+  namespace: janet
 spec:
   interval: 5m
   url: oci://ghcr.io/freckleapps/janet-manifests

--- a/kubernetes/apps/networking/netflow/akvorado/service-inlet.yaml
+++ b/kubernetes/apps/networking/netflow/akvorado/service-inlet.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/core/service_v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.26.1-standalone-strict/service-v1.json
 #
 # Flow ingest endpoint. Hand-written rather than rendered by app-template
 # because that chart has no way to set externalTrafficPolicy, and we need it:


### PR DESCRIPTION
Both checks are currently red on **every** open PR. `Image Pull - Success` is the only required check in the branch ruleset, so nothing can merge until this lands.

## Image Pull (required check)

`home-operations/flate/action` defaults its `base` input to the repo's default branch, exporting `FLATE_BASE=main`. A non-empty base puts flate in *changed-only* mode.

That breaks the `pull` matrix leg: `actions/checkout` lands a shallow detached PR ref, so neither a local `main` nor `origin/main` exists and flate exits 1:

```
flate error: could not resolve --base="main": not found locally or as origin/main
```

The `default` leg survives only because `ref: main` creates a local branch of that name.

Changed-only mode is the wrong mode here anyway — the `diff` job computes `pull - default` and needs the **full** image list from both sides. Per flate's own flag docs, omitting `--base` on `build`/`get`/`test` "keeps the default full-tree behavior", so an empty base is exactly what this job wants.

## Schema Validation (hygiene check)

`akvorado/service-inlet.yaml` referenced `k8s-schemas.freckle.systems/core/service_v1.json`, which 404s. That host is generated by `crd-extractor.sh` in `schemas-extract.yaml`, which walks `kubectl get crd` — core/v1 built-ins are never published there, so no `core/*` URL will ever resolve.

Switched to the yannh standalone-strict schema, matching the existing precedent for a built-in type in `apps/auth/lldap/pvc.yaml`.

No cluster-visible change — the schema comment is IDE-only metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and offline-render fixes plus an IDE schema comment; OCIRepository namespace matches live Flux targetNamespace and does not change runtime behavior.
> 
> **Overview**
> Restores the **required Image Pull** workflow and fixes a **schema validation** 404 so PRs can merge again.
> 
> **Image Pull extract job** sets flate `base: ""` so both matrix legs (`default` and `pull`) enumerate the **full** image tree for the diff job, instead of changed-only mode that breaks on shallow PR checkouts when resolving `main`.
> 
> **Gather Images** now passes `--allow-missing-secrets` (for `ghcr-pull` from ClusterExternalSecret, not in-repo ExternalSecrets), tolerates flate non-zero exit when reconcile reports **0 failures** but Kustomizations are blocked on offline-only `k8s-cluster-info` substitutes, surfaces warnings in the step summary, and validates `images.json` is a JSON array before downstream `jq`.
> 
> **OCIRepository** resources for **hedgehog** and **janet** add explicit `metadata.namespace` so offline flate/static discovery resolves `sourceRef` correctly instead of aliasing to the infra repo root.
> 
> **akvorado** `service-inlet.yaml` swaps the yaml-language-server schema URL to yannh's `service-v1.json` (IDE-only; no cluster change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0931afde2bf6c04fc6ebae2e5033b00fd1cb79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->