### PR TITLE
fix(nautobot): give migrations headroom and stop rolling them back

### DIFF
--- a/kubernetes/apps/nautobot/app/helmrelease.yaml
+++ b/kubernetes/apps/nautobot/app/helmrelease.yaml
@@ -18,12 +18,24 @@ spec:
     remediation:
       retries: 3
   upgrade:
-    # Same headroom — the release already exists, so the fix rolls as an
-    # upgrade and migrations run in the upgrade hook.
-    timeout: 10m
+    # 20m, and deliberately NOT rolled back on failure.
+    #
+    # Migrations do NOT run in a hook Job — that only happens with
+    # `nautobot.singleInit: true`, which we do not set. They run in the web
+    # Deployment's `nautobot-init` init container, so the Helm timeout races
+    # the Deployment's own progressDeadlineSeconds (k8s default 600s = the old
+    # 10m here). Nautobot 3.2.x migrations are irreversible — dcim/0090 drops
+    # 30 columns — so a timeout that triggered Flux's default `rollback`
+    # remediation would put the 3.1.x image back in front of an already-migrated
+    # schema, which fails every cable/interface query. That is a self-inflicted
+    # outage, and rolling forward is the only real recovery.
+    #
+    # retries: 0 so a slow migration is reported as a stuck HelmRelease we can
+    # look at, rather than silently reverted three times.
+    timeout: 20m
     cleanupOnFail: true
     remediation:
-      retries: 3
+      retries: 0
   uninstall:
     keepHistory: false
   values:


### PR DESCRIPTION
Prep for #2190 (nautobot 3.1.8 → 3.2.1). Merge this first.

3.2.1 carries **18 irreversible migrations** — `dcim/0090` alone issues 30 `RemoveField` ops, dropping the legacy cable/termination columns. Reverting the image tag after they run does **not** work: 3.1.8's ORM selects those columns on every cable/interface/circuit query and 500s immediately. Rollback means restoring the database.

That makes the current HelmRelease settings actively dangerous.

## Migrations don't run in a hook Job

The existing comment says they do. That's only true with `nautobot.singleInit: true`, which we don't set. They actually run in the web Deployment's `nautobot-init` **init container** — so the 10m Helm timeout was racing the Deployment's own `progressDeadlineSeconds`, which defaults to exactly 600s. Comment corrected.

## The remediation was the real hazard

Flux's default upgrade remediation strategy is `rollback`. If migrations overran 10m, Flux would reinstall 3.1.x **in front of an already-migrated schema** — a self-inflicted outage recoverable only by rolling forward or restoring from backup. With `retries: 3` it would have done that three times.

## Change

- `timeout: 10m` → `20m`
- `remediation.retries: 3` → `0`, so a slow migration surfaces as a stuck HelmRelease to inspect rather than being silently reverted

`install` is left at 10m/3 — a fresh install has no schema to strand, so rollback is safe there.

No image change; the running 3.1.8 release is untouched by this PR.