### PR TITLE
fix(flux): codify the envoy-ai-gateway pointers on atlantis

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system/envoy-ai-gateway.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system/envoy-ai-gateway.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app envoy-ai-gateway
+  namespace: &namespace envoy-ai-gateway-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # Envoy AI Gateway registers itself as an Envoy Gateway extension, so EG
+    # must be up first.
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  targetNamespace: *namespace
+  path: ./kubernetes/apps/networking/envoy-ai-gateway/controller
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m
+  timeout: 5m
+  wait: true

--- a/kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: envoy-ai-gateway-system
+components:
+  - ../../../../components/flux-post-build-variables
+resources:
+  - ./envoy-ai-gateway.yaml

--- a/kubernetes/clusters/atlantis-k8s01/flux/envoy-ai-gateway-system.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/flux/envoy-ai-gateway-system.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: envoy-ai-gateway-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app envoy-ai-gateway-system-apps
+  namespace: &namespace envoy-ai-gateway-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system
+  interval: 2m
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: false


### PR DESCRIPTION
Found while researching the Envoy Gateway v1.8.3 bump (#2166).

These three files describe a workload that is **live but was never committed**. `ai-gateway-controller` has been Running in `envoy-ai-gateway-system` for weeks, yet:

- the namespace still carries `kubectl.kubernetes.io/last-applied-configuration` — it was `kubectl apply`'d by hand, not reconciled;
- the parent `envoy-ai-gateway-system-apps` Kustomization **does not exist in-cluster at all**, so the child `envoy-ai-gateway` KS is orphaned — reconciling from git with nothing owning it.

## Why this is more than hygiene

Envoy Gateway's `extensionManager` (`kubernetes/apps/networking/envoy-gateway/controller/helmrelease.yaml`) is in the **shared** app dir and points *both* clusters at this extension server. It resolves today only because the server happens to be running on atlantis.

Rebuilding atlantis from git alone would not recreate it. Envoy Gateway would start up pointing at a Service that doesn't exist — which is exactly the cluster-wide xDS outage this repo has hit before, and which needs an EG restart to recover from.

## Verified no-op

Committing creates the missing parent, which then adopts the existing child. Checked against the live objects first:

| | live | this file |
|---|---|---|
| child KS `path` | `./kubernetes/apps/networking/envoy-ai-gateway/controller` | same |
| child KS `prune` | `true` | same |
| child KS `interval` | `30m` | same |
| namespace prune annotation | `disabled` | same |

The app dir it points at (`kubernetes/apps/networking/envoy-ai-gateway/controller`) is already tracked. No workload change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster networking bootstrap order (Envoy Gateway extension dependency); runtime should be a no-op if live objects match, but mis-sync could affect EG xDS on rebuild.
> 
> **Overview**
> Adds the missing **atlantis** Flux chain for `envoy-ai-gateway-system` so the live AI gateway controller is owned by git instead of hand-applied objects.
> 
> A root `flux/envoy-ai-gateway-system.yaml` defines the namespace (prune disabled) and parent Kustomization `envoy-ai-gateway-system-apps`, which points at a new cluster app kustomization that deploys the child Flux KS `envoy-ai-gateway`. That child still applies the shared path `./kubernetes/apps/networking/envoy-ai-gateway/controller` with `dependsOn` **envoy-gateway**, matching what is already running in-cluster.
> 
> **No workload or Helm changes**—this closes the gap where Envoy Gateway’s shared `extensionManager` expects the extension server on atlantis, but a git-only cluster rebuild would not recreate it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8faafff13130e3011017fc8dc9012b69a8db6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->