### PR TITLE
fix(zigbee): drop the dead ZIGBEE2MQTT_CONFIG_PERMIT_JOIN var

### DIFF
--- a/kubernetes/apps/home-automation/zigbee/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee/helmrelease.yaml
@@ -48,7 +48,6 @@ spec:
               ZIGBEE2MQTT_CONFIG_MQTT_REJECT_UNAUTHORIZED: "true"
               ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto:1883
               ZIGBEE2MQTT_CONFIG_MQTT_VERSION: 5
-              ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: "false"
               # Cluster-specific serial adapter/baud/port set via Flux
               # KS patches (e.g. fairy points at the zigbee01 bridge).
 


### PR DESCRIPTION
Found while researching the zigbee2mqtt 2.12.1 → 2.13.0 bump (#2206).

`permit_join` stopped being a **configuration setting** in zigbee2mqtt 2.0.0. Joining is now a runtime operation over `zigbee2mqtt/bridge/request/permit_join`. So `ZIGBEE2MQTT_CONFIG_PERMIT_JOIN` has been a no-op for our entire time on 2.x — it maps to a key that no longer exists in the settings schema, and z2m parses then discards it.

## Verified against the running image, not the changelog

```
$ grep -o permit_join /app/dist/util/settings.schema.json
(no output)

$ grep -rl permit_join /app/dist
/app/dist/extension/bridge.d.ts
/app/dist/extension/bridge.js
/app/dist/extension/homeassistant.js
```

Every surviving reference is on the runtime request / HA-discovery path. None is config.

## No behavior change

Joining is already disabled by default at runtime and is unaffected by this key in either direction. This only removes a line that reads as if it were enforcing something.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line deletion of an ignored env var with no change to join behavior or security posture.
> 
> **Overview**
> Removes **`ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: "false"`** from the zigbee2mqtt HelmRelease env block in `helmrelease.yaml`.
> 
> That variable mapped to a **`permit_join`** config key removed in zigbee2mqtt 2.0.0; on 2.x it was ignored by the settings schema. **Permit join** is controlled at runtime via MQTT (`zigbee2mqtt/bridge/request/permit_join`), not static config.
> 
> **No expected runtime change** — joining behavior and defaults stay the same; this only drops misleading dead configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ddb1ddd851e42a2fef89982f65e6b6f74c4d82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->