### PR TITLE
fix(flux): restore CLUSTER_SVCS_DOMAIN until consumers inline it

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
@@ -18,4 +18,10 @@ data:
   CLUSTER_NAME: "atlantis-k8s01"
   CLUSTER_SUBDOMAIN: "atlantis"
   CLUSTER_DOMAIN: "atlantis.freckle.systems"
+  # Restored after #2233 dropped it: consumers still reference
+  # ${CLUSTER_SVCS_DOMAIN} and Flux post-build substitution is strict, so a
+  # missing key fails the whole Kustomization rather than degrading. Retire
+  # this once every consumer inlines the real domain (hedgehog's bundle is
+  # the last one on atlantis; technitium references it on fairy).
+  CLUSTER_SVCS_DOMAIN: "atlantis.freckle.services"
   GARAGE_S3_REGION: "us-den1"

--- a/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
@@ -18,3 +18,9 @@ data:
   CLUSTER_NAME: "fairy-k8s01"
   CLUSTER_SUBDOMAIN: "fairy"
   CLUSTER_DOMAIN: "fairy.freckle.systems"
+  # Restored after #2233 dropped it: consumers still reference
+  # ${CLUSTER_SVCS_DOMAIN} and Flux post-build substitution is strict, so a
+  # missing key fails the whole Kustomization rather than degrading. Retire
+  # this once every consumer inlines the real domain (hedgehog's bundle is
+  # the last one on atlantis; technitium references it on fairy).
+  CLUSTER_SVCS_DOMAIN: "fairy.freckle.services"


### PR DESCRIPTION
Unblocks `hedgehog` on atlantis, which has been unable to apply since #2233.

## What happened

#2233 dropped `CLUSTER_SVCS_DOMAIN` from both the cluster-info ConfigMap and the `k8s-cluster-secrets` ExternalSecret, as part of inlining real domains. But hedgehog's OCI bundle still substitutes `${CLUSTER_SVCS_DOMAIN}`, and Flux post-build substitution is **strict** — a missing key fails the whole Kustomization rather than degrading to an empty string:

```
Kustomization/hedgehog/hedgehog: post build failed for
'HTTPRoute.v1.gateway.networking.k8s.io/hedgehog-serve': envsubst error:
variable substitution failed: variable not set (strict mode): "CLUSTER_SVCS_DOMAIN"
```

hedgehog kept serving off its last good apply — all pods Running, DB healthy — but could not take any new change. Blast radius was 1 Kustomization on atlantis, 0 on fairy.

## Values

Exactly the ones #2233 removed, and they match the hostname on the live HTTPRoute (`hedgehog.atlantis.freckle.services`):

| cluster | value |
|---|---|
| atlantis-k8s01 | `atlantis.freckle.services` |
| fairy-k8s01 | `fairy.freckle.services` |

Restored on **fairy too**, even though nothing there references it today: the in-progress `technitium` manifests use `${CLUSTER_SVCS_DOMAIN}` in `DNS_SERVER_DOMAIN` and a hostname, so keeping the clusters symmetric avoids the identical failure landing there when that work merges.

## Not a reversal of #2233

This is a stopgap. The inline-real-domains direction stands — the comment on each key marks it for removal once the last two consumers inline the domain themselves (hedgehog's bundle lives in the app repo; technitium is still WIP here).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change restoring previously used cluster substitution values; no auth, data, or runtime logic changes.
> 
> **Overview**
> **Re-adds `CLUSTER_SVCS_DOMAIN`** to the shared `k8s-cluster-info` ConfigMap on **atlantis-k8s01** (`atlantis.freckle.services`) and **fairy-k8s01** (`fairy.freckle.services`), reversing the removal in #2233.
> 
> Flux post-build substitution is strict: manifests that still use `${CLUSTER_SVCS_DOMAIN}` (e.g. hedgehog’s HTTPRoute on atlantis) fail the whole Kustomization when the key is missing. Restoring the value unblocks applies without changing live hostnames.
> 
> Comments on each key mark this as a **temporary stopgap** until hedgehog and technitium inline real domains; the inline-real-domains direction from #2233 is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af5f72557180f264bdfcd6346b7b5db66b76064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->