### PR TITLE
feat(qwen): cache the checkpoint to node-local NVMe like minimax

### DIFF
--- a/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
+++ b/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
@@ -66,7 +66,7 @@ spec:
         # --safetensors-load-strategy=prefetch instead would have been the wrong
         # fix on GB10, where page cache and "GPU" memory are the same pool.
         - name: cache-models
-          image: mirror.gcr.io/rclone/rclone:1.74.4@sha256:c61954aaa32328a5486715dd063a81c7879f5195ad3505cd362deddd509dc4a1
+          image: mirror.gcr.io/rclone/rclone:1.75.0@sha256:b06aed988cf5967de7c25be5925240983981c757f4ed1ac9d2fa659d51d60548
           command:
             - rclone
             - sync

--- a/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
+++ b/kubernetes/apps/inference/models/qwen36-35b-a3b/deployment.yaml
@@ -13,6 +13,13 @@ metadata:
   name: qwen36-35b-a3b
 spec:
   replicas: 1
+  # Default is 600s, which the first rollout on a node would blow through: the
+  # init container has to pull ~35Gi off CephFS before vLLM even starts, and the
+  # startupProbe then allows another 30m. Flux health-checks this Deployment
+  # (wait: true) and kstatus treats ProgressDeadlineExceeded as failed, so the
+  # default would fail the Kustomization on a cold node while the sync was still
+  # legitimately running. Aligned with the pointer KS's own 30m timeout.
+  progressDeadlineSeconds: 1800
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -43,12 +50,52 @@ spec:
       resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu
+      initContainers:
+        # Cache the checkpoint from CephFS to node-local NVMe before vLLM starts,
+        # same pattern as the minimax LeaderWorkerSet. --copy-links dereferences
+        # the HF-cache symlinks so the local copy is self-contained; scoped to the
+        # Qwen dir (the `models` PVC is shared with minimax + gpt-oss) and excludes
+        # blobs/ because the deref'd snapshot already carries that data — without
+        # the exclude this would land ~70Gi instead of ~35Gi. hostPath persists
+        # across pod restarts, so only the first pod on a node pays the full sync
+        # and later ones re-sync incrementally.
+        #
+        # This also removes the reason vLLM logged "Auto-prefetch is disabled
+        # because the filesystem (CEPH) is not a recognized network FS": weights
+        # are read from local NVMe now, so the prefetch heuristic is moot. Forcing
+        # --safetensors-load-strategy=prefetch instead would have been the wrong
+        # fix on GB10, where page cache and "GPU" memory are the same pool.
+        - name: cache-models
+          image: mirror.gcr.io/rclone/rclone:1.74.4@sha256:c61954aaa32328a5486715dd063a81c7879f5195ad3505cd362deddd509dc4a1
+          command:
+            - rclone
+            - sync
+            - /ceph-models/hub/models--Qwen--Qwen3.6-35B-A3B-FP8/
+            - /models/hub/models--Qwen--Qwen3.6-35B-A3B-FP8/
+            - --copy-links
+            - --exclude
+            - blobs/**
+            - --transfers
+            - "8"
+            - --checkers
+            - "16"
+            # One-line stats each minute instead of --progress (which floods
+            # non-TTY pod logs with continuous progress redraws).
+            - --stats
+            - 1m
+            - --stats-one-line
+          volumeMounts:
+            - name: ceph-models
+              mountPath: /ceph-models
+              readOnly: true
+            - name: local-models
+              mountPath: /models
       containers:
         - name: vllm
-          # v0.24.0 (CUDA-13 default, Ubuntu 24.04) via the GCR pull-through mirror
-          # (avoids Docker Hub rate limits). v0.24's Responses-API parser handles
-          # codex's multi-turn tool loop, so this one deploy serves brain chat AND
-          # coding. NOT the older v0.20 (its /responses couldn't parse tool results).
+          # CUDA-13 default, Ubuntu 24.04, via the GCR pull-through mirror (avoids
+          # Docker Hub rate limits). The Responses-API parser handles codex's
+          # multi-turn tool loop, so this one deploy serves brain chat AND coding.
+          # NOT the older v0.20 (its /responses couldn't parse tool results).
           image: mirror.gcr.io/vllm/vllm-openai:v0.26.0-aarch64-ubuntu2404
           command:
             - vllm
@@ -105,7 +152,8 @@ spec:
           env:
             - name: HF_HOME
               value: /models
-            # Weights are pre-staged on CephFS; never reach HF at serve time
+            # Weights are pre-staged on CephFS and cached to node-local NVMe by
+            # the init container; never reach HF at serve time
             # (egress is locked — see cnp.yaml). Offline + no telemetry.
             - name: HF_HUB_OFFLINE
               value: "1"
@@ -134,7 +182,9 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            # Long — first load is weights from CephFS + torch.compile + cudagraph capture.
+            # Long — covers vLLM's load from node-local NVMe (the CephFS->local
+            # sync happens in the init container, before this probe starts) plus
+            # torch.compile and cudagraph capture.
             failureThreshold: 180
           livenessProbe:
             httpGet:
@@ -154,7 +204,9 @@ spec:
             claims:
               - name: gpu
           volumeMounts:
-            - name: models
+            # HF_HOME points here; this is the node-local NVMe cache the init
+            # container populated, not the CephFS PVC.
+            - name: local-models
               mountPath: /models
             - name: shm
               mountPath: /dev/shm
@@ -162,9 +214,17 @@ spec:
               mountPath: /config
               readOnly: true
       volumes:
-        - name: models
+        # Source: shared models PVC on CephFS (read-only; the init copies out of it).
+        - name: ceph-models
           persistentVolumeClaim:
             claimName: models
+            readOnly: true
+        # Dest: node-local NVMe cache. hostPath persists across pod restarts so the
+        # CephFS sync is a one-time-per-node cost; vLLM reads weights from here.
+        - name: local-models
+          hostPath:
+            path: /var/local/inference-models
+            type: DirectoryOrCreate
         - name: shm
           emptyDir:
             medium: Memory


### PR DESCRIPTION
Qwen was the last GPU workload still reading weights straight off the shared CephFS PVC at load time. This adopts the **same rclone init container the minimax LeaderWorkerSet already uses**.

## What it does

Syncs the ~35 Gi checkpoint from the shared `models` PVC to node-local NVMe (`hostPath: /var/local/inference-models`) before vLLM starts, then points `HF_HOME` at the local copy.

- `--copy-links` dereferences the HF-cache symlinks so the local tree is self-contained
- `blobs/**` is excluded because the deref'd snapshot already carries that data — **without the exclude this lands ~70 Gi instead of ~35 Gi**
- the hostPath persists across pod restarts, so only the first pod on a node pays the full sync; later ones re-sync incrementally

Verified before writing it: the cache dir really is `models--Qwen--Qwen3.6-35B-A3B-FP8` (35 G, with `snapshots/` being 28 K of symlinks), and qwen's node `fairy-r02-dgx01` has **3673 GB free (3% used)**.

## It also answers the prefetch question properly

vLLM logs this on startup today:

```
Auto-prefetch is disabled because the filesystem (CEPH) is not a recognized
network FS (NFS/Lustre). If you want to force prefetching, start vLLM with
--safetensors-load-strategy=prefetch.
```

With weights on local NVMe the heuristic is moot. Forcing prefetch would have been the **wrong** fix on GB10: it reads the whole safetensors file into page cache before mmap, and on unified memory that is the same pool vLLM is reserving for weights and KV cache — the exact axis these deployments have OOM'd on before. Moving to NFS would also have been wrong: that message is a whitelist miss in vLLM's FS detection, not a verdict on CephFS.

## progressDeadlineSeconds

Added at `1800`. The default is 600s, which a first sync on a cold node would blow through. The pointer Kustomization health-checks this Deployment (`wait: true`) and kstatus treats `ProgressDeadlineExceeded` as **failed**, so the default would have failed the Kustomization while the sync was still legitimately running. Aligned with that KS's own `timeout: 30m`.

## Notes

- Server-side dry-run passes. The PodSecurity warnings are advisory only — namespace enforces `privileged`, and the existing `vllm` container already trips the same rules.
- Pinned to the same rclone digest minimax uses, so #2208 moves both together.
- Also de-stales the image comment, which still said v0.24.0 after #2194 moved the tag to v0.26.0.
- **This will restart qwen**, and the first rollout pays the one-time ~35 Gi sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference weight loading and rollout timing (hostPath cache, long init sync); first deploy restarts Qwen and can take up to ~30m before healthy, but mirrors an already-proven minimax pattern.
> 
> **Overview**
> Qwen’s vLLM deployment no longer reads weights directly from the shared CephFS `models` PVC at startup. It now follows the **same minimax pattern**: an `rclone` init container syncs the ~35 Gi Qwen checkpoint from CephFS into node-local NVMe (`hostPath` `/var/local/inference-models`), with `--copy-links` and `blobs/**` excluded so the cache stays ~35 Gi instead of ~70 Gi. vLLM’s `HF_HOME` and weight mounts point at that local tree; CephFS is read-only for the init copy only.
> 
> **`progressDeadlineSeconds`** is raised to **1800** so Flux/kstatus health checks (`wait: true`) don’t fail the Kustomization on a cold node while the init sync and long startup probe (compile/cudagraph) are still running—aligned with the pointer KS’s 30 m timeout.
> 
> Comments are updated for local NVMe load vs CephFS and the v0.26 image line is de-staled. **Expect a pod restart**; the first rollout on a node pays the one-time ~35 Gi sync (later restarts re-sync incrementally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0549808d2fb4b829e732a8820288fe1582a1eaed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->