### PR TITLE
fix(observability): collect logs and traces from the GPU nodes

### DIFF
--- a/kubernetes/apps/observability/opentelemetry-collector/collector.yaml
+++ b/kubernetes/apps/observability/opentelemetry-collector/collector.yaml
@@ -21,6 +21,15 @@ metadata:
 spec:
   mode: daemonset
   serviceAccount: otel-collector
+  # Same reason as the vector DaemonSet: the DGX Spark nodes carry
+  # nvidia.com/gpu:NoSchedule, so without this the collector never lands on
+  # them and GPU workloads can emit no traces or metrics through OTLP. The
+  # sparks are arm64 and otel/opentelemetry-collector-contrib publishes
+  # linux/arm64, so the existing image works unchanged.
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
   image: otel/opentelemetry-collector-contrib:0.157.0
   resources:
     requests:

--- a/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/helmrelease.yaml
@@ -60,6 +60,16 @@ spec:
     vector:
       enabled: true
       resources: {}
+      # The three DGX Spark nodes are tainted nvidia.com/gpu:NoSchedule, and
+      # without this the DaemonSet reports desired: 3 — it only ever targets the
+      # amd64 nodes. Every GPU workload (the vLLM model servers) was therefore
+      # producing no collected logs at all: a crash or OOM left nothing behind
+      # once the pod was gone. The sparks are arm64; timberio/vector publishes
+      # linux/arm64, so no image change is needed.
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
       # Override the chart default config to also tail kube-apiserver
       # audit logs from each CP node's hostPath /var/log/audit/. Audit
       # is enabled via talconfig.yaml at Metadata level.


### PR DESCRIPTION
Found while trying to retrieve a historical vLLM startup metric and getting zero results.

## The gap

Neither the `vector` nor the `otel-collector` DaemonSet tolerated `nvidia.com/gpu:NoSchedule`, so on a six-node cluster both reported **`desired: 3`** — they only ever ran on the amd64 nodes, never on the three DGX Sparks.

So **every GPU workload has been invisible to observability.** Over a 15-day window the `inference` namespace has streams only from the AI gateway (`ai-*`) and the LWS controller — not a single line from `qwen36-35b-a3b`, `minimax-m27-nvfp4`, or `gpt-oss`.

That's the worst possible set of workloads to lose. A model server that OOMs or hits a CUDA fault leaves nothing behind once the pod is replaced, and `kubectl logs` only reaches a live pod. Today that meant a pre-upgrade KV-cache baseline simply didn't exist to compare against.

## arm64

The sparks are **arm64** while the rest of the cluster is amd64, so a naive toleration could have swapped a scheduling gap for a crashloop. Checked both registry manifest lists first — no image or `nodeSelector` change needed:

| image | platforms |
|---|---|
| `timberio/vector:0.57.0-distroless-libc` | amd64, **arm64**, arm/v7 |
| `otel/opentelemetry-collector-contrib:0.157.0` | amd64, **arm64**, 386, arm/v7, ppc64le, riscv64, s390x |

## Verification

- Rendered `victoria-logs-single` 0.13.9 with **this repo's actual values** (not a synthetic snippet) and confirmed the toleration reaches the DaemonSet pod spec with the image unchanged. The vector subchart consumes `.Values.tolerations` via `templates/_pod.tpl`.
- Server-side dry-run of the `OpenTelemetryCollector` CR passes.

## Expected effect

Both DaemonSets should go `desired: 3 → 6`. After rollout, `{kubernetes.pod_namespace="inference"}` should start showing streams from the vLLM pods.

Note the stream field is `kubernetes.pod_namespace`, not `namespace` — worth knowing for anyone querying VictoriaLogs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduling-only toleration additions on observability DaemonSets; no auth, data-path, or image changes.
> 
> **Overview**
> GPU nodes (DGX Sparks) use the **`nvidia.com/gpu:NoSchedule`** taint, so the **Vector** log collector and **OpenTelemetry Collector** DaemonSets only scheduled on the three amd64 nodes (`desired: 3` on a six-node cluster). vLLM and other GPU workloads on the sparks had **no collected logs** and **no OTLP traces/metrics** through the per-node collectors.
> 
> This change adds the same **`nvidia.com/gpu` Exists / NoSchedule** toleration to both DaemonSets (in `collector.yaml` and the victoria-logs `helmrelease` vector values). Existing **amd64/arm64** images are unchanged.
> 
> After rollout, both DaemonSets should scale to **six** pods and inference-namespace streams should include the model-server pods, not only gateway/LWS controller traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc9067744e3f06cd9b955d99b826f08dcd012d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->