### PR TITLE
fix(netdisco): run web and backend in one pod so the RWO volume works

### DIFF
--- a/kubernetes/apps/networking/netdisco/deployment.yaml
+++ b/kubernetes/apps/networking/netdisco/deployment.yaml
@@ -1,19 +1,37 @@
 ---
+# web and backend in ONE pod, deliberately.
+#
+# They were two Deployments, but both mount the same `netdisco-data` PVC, which
+# is RWO on ceph-block. That only worked for as long as both happened to land on
+# the same node. After the Talos v1.13.7 rolling reboots they scattered — web to
+# fairy-compute03, backend to fairy-r02-cn01 — and the volume can only attach to
+# one node, so backend sat in ContainerCreating for hours with two live
+# VolumeAttachments fighting over it. Nothing was "stuck" in a way that would
+# self-heal; it would have recurred after every node reboot.
+#
+# Co-locating them in a single pod makes the shared RWO volume structurally
+# correct rather than coincidentally correct. The two containers already had
+# byte-identical env, volumeMounts and securityContext — the only differences
+# were the image tag and the web port — so nothing is lost by merging.
+#
+# strategy: Recreate is load-bearing. With the default RollingUpdate, an update
+# would start the replacement pod (possibly on another node) while the old pod
+# still holds the RWO volume, reproducing the exact deadlock this commit fixes.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: netdisco-web
+  name: netdisco
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: netdisco
-      app.kubernetes.io/component: web
   template:
     metadata:
       labels:
         app.kubernetes.io/name: netdisco
-        app.kubernetes.io/component: web
     spec:
       containers:
         - name: web
@@ -21,7 +39,7 @@ spec:
           envFrom:
             - secretRef:
                 name: netdisco
-          env:
+          env: &dbEnv
             - name: NETDISCO_DB_HOST
               value: netdisco-rw
             - name: NETDISCO_DB_NAME
@@ -39,7 +57,7 @@ spec:
           ports:
             - containerPort: 5000
               name: http
-          volumeMounts:
+          volumeMounts: &dataMounts
             - name: data
               mountPath: /home/netdisco/nd-site-local
               subPath: nd-site-local
@@ -49,62 +67,13 @@ spec:
             - name: data
               mountPath: /home/netdisco/logs
               subPath: logs
-      securityContext:
-        runAsUser: 901
-        runAsGroup: 901
-        fsGroup: 901
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: netdisco-data
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: netdisco-backend
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: netdisco
-      app.kubernetes.io/component: backend
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: netdisco
-        app.kubernetes.io/component: backend
-    spec:
-      containers:
         - name: backend
           image: mirror.gcr.io/netdisco/netdisco:2.098002-backend
           envFrom:
             - secretRef:
                 name: netdisco
-          env:
-            - name: NETDISCO_DB_HOST
-              value: netdisco-rw
-            - name: NETDISCO_DB_NAME
-              value: app
-            - name: NETDISCO_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: netdisco-db-secret
-                  key: username
-            - name: NETDISCO_DB_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: netdisco-db-secret
-                  key: password
-          volumeMounts:
-            - name: data
-              mountPath: /home/netdisco/nd-site-local
-              subPath: nd-site-local
-            - name: data
-              mountPath: /home/netdisco/environments
-              subPath: environments
-            - name: data
-              mountPath: /home/netdisco/logs
-              subPath: logs
+          env: *dbEnv
+          volumeMounts: *dataMounts
       securityContext:
         runAsUser: 901
         runAsGroup: 901

--- a/kubernetes/apps/networking/netdisco/service.yaml
+++ b/kubernetes/apps/networking/netdisco/service.yaml
@@ -4,9 +4,10 @@ kind: Service
 metadata:
   name: netdisco
 spec:
+  # No component selector: web and backend are one pod now, so name alone is
+  # unambiguous. The port still resolves to the web container's `http` port.
   selector:
     app.kubernetes.io/name: netdisco
-    app.kubernetes.io/component: web
   ports:
     - name: http
       port: 5000


### PR DESCRIPTION
`netdisco-backend` has been stuck in `ContainerCreating` for 3h+. This is a design fix, not a restart.

## What was wrong

Both `netdisco-web` and `netdisco-backend` mount the same `netdisco-data` PVC — **RWO on ceph-block**. That only works while both pods land on the *same node*.

The Talos v1.13.7 rolling reboots scattered them:

```
netdisco-web      -> fairy-compute03    Running
netdisco-backend  -> fairy-r02-cn01     ContainerCreating (3h+)
```

with two live VolumeAttachments contending for one PV:

```
csi-409bd...  node=fairy-r02-cn01    attached=true
csi-93b3a...  node=fairy-compute03   attached=true
```

An RBD volume attaches to exactly one node, so backend could never mount. This was **not** a stale attachment to clean up — deleting the compute03 one would just have broken `web` instead. And it would recur after **every** node reboot.

## The fix

One pod, two containers. The volume is shared inside a pod, which is what RWO actually supports.

The containers already had **byte-identical** `envFrom`, `env`, `volumeMounts` and `securityContext` — the only differences were the image tag and web's port 5000. So nothing is lost. Those shared blocks are now YAML anchors (`&dbEnv` / `&dataMounts`) so they can't silently drift apart.

**`strategy: Recreate` is the load-bearing part.** Under the default RollingUpdate, any future update would start the replacement pod — possibly on a different node — while the outgoing pod still held the RWO volume, reproducing this exact deadlock. Recreate makes the old pod release the volume first.

## Service

Drops the `component: web` selector, since one Deployment makes `app.kubernetes.io/name: netdisco` unambiguous. Verified the new pod labels still satisfy it, so the HTTPRoute backendRef is unaffected.

## Verification

- `kubectl kustomize | kubectl apply --dry-run=server`: `deployment.apps/netdisco created`, `service/netdisco configured`
- Confirmed both containers render with the anchored env/mounts, and only `web` exposes port 5000
- (The HTTPRoute's `${CLUSTER_DOMAIN}` fails raw dry-run as expected — Flux substitutes it via postBuild.)

## Rollout note

Flux will create `netdisco` and prune `netdisco-web` / `netdisco-backend`. The new pod may sit Pending for a minute or two until the old attachments release — that's the normal RBD detach, not the old bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Netdisco deployment topology and rollout strategy; misconfiguration could cause brief downtime during Flux prune/create, but the change directly fixes a recurring RWO scheduling failure rather than altering auth or data semantics.
> 
> **Overview**
> **Merges `netdisco-web` and `netdisco-backend` into a single `netdisco` Deployment** with two containers sharing one pod. Both previously mounted the same **RWO** `netdisco-data` PVC on ceph-block; that only worked when both pods scheduled on the same node. After node reboots they split across nodes, leaving `netdisco-backend` stuck in `ContainerCreating` with competing VolumeAttachments—an issue that would repeat on every reboot.
> 
> The combined pod shares env and volume mounts via YAML anchors (`&dbEnv`, `&dataMounts`); only the web image tag and port 5000 differ. **`strategy: Recreate`** is required so updates release the RWO volume before the replacement pod starts (RollingUpdate would recreate the same deadlock).
> 
> The **Service** drops `app.kubernetes.io/component: web` from its selector; `app.kubernetes.io/name: netdisco` alone targets the unified pod while HTTP still hits the web container’s `http` port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 176d50ceaa6e545d1db9e6b0027f865aa2770534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->