### PR TITLE
refactor(flux): declare k8s-cluster-info per namespace on fairy

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/kustomization.yaml
@@ -1,15 +1,19 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 #
-# Not a namespace directory and not pointed at by any Flux Kustomization. It
-# exists so that a namespace's kustomization.yaml can pull k8s-cluster-info into
-# its own namespace with `- ../_shared/cluster-info`, which kustomize permits
-# only for directories — a bare `../default/k8s-cluster-info.yaml` is rejected
-# as a load-restrictor violation, and Flux gives us no way to relax that.
+# A kustomize Component, not a namespace: it is listed under `components:` by
+# every namespace on this cluster, alongside flux-post-build-variables, and no
+# Flux Kustomization points at it directly.
+#
+# It exists because Flux resolves postBuild.substituteFrom only in the
+# Kustomization's own namespace, so each namespace needs its own copy of
+# k8s-cluster-info. Sharing one file keeps the values from drifting.
 #
 # Deliberately carries no `namespace:` — the including kustomization's own
-# namespace transformer places it.
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+# namespace transformer places the ConfigMap. A kustomization with no such
+# transformer (cluster-scoped dirs like ghcr-pull) must NOT include this, or the
+# ConfigMap lands in `default` and collides with the copy declared there.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 resources:
   - ./k8s-cluster-info.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/default/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/default/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./app-template.yaml
-  - ../_shared/cluster-info
   - ./k8s-cluster-secrets.yaml
 patches:
   # Only the `default` copy is a Reflector source. Namespaces that declare

--- a/kubernetes/clusters/atlantis-k8s01/apps/konflate/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/konflate/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: konflate
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   # Laid down here rather than relied on from Reflector. The child Kustomization
@@ -16,7 +17,6 @@ resources:
   #
   # Same file as the `default` copy, so the values cannot drift; the namespace
   # comes from the `namespace:` transformer above.
-  - ../_shared/cluster-info
   # SA + gcp-sm SecretStore the konflate-webhook ExternalSecret reads through.
   - ./external-secrets.yaml
   - ./konflate.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/kustomization.yaml
@@ -1,15 +1,19 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 #
-# Not a namespace directory and not pointed at by any Flux Kustomization. It
-# exists so that a namespace's kustomization.yaml can pull k8s-cluster-info into
-# its own namespace with `- ../_shared/cluster-info`, which kustomize permits
-# only for directories — a bare `../default/k8s-cluster-info.yaml` is rejected
-# as a load-restrictor violation, and Flux gives us no way to relax that.
+# A kustomize Component, not a namespace: it is listed under `components:` by
+# every namespace on this cluster, alongside flux-post-build-variables, and no
+# Flux Kustomization points at it directly.
+#
+# It exists because Flux resolves postBuild.substituteFrom only in the
+# Kustomization's own namespace, so each namespace needs its own copy of
+# k8s-cluster-info. Sharing one file keeps the values from drifting.
 #
 # Deliberately carries no `namespace:` — the including kustomization's own
-# namespace transformer places it.
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+# namespace transformer places the ConfigMap. A kustomization with no such
+# transformer (cluster-scoped dirs like ghcr-pull) must NOT include this, or the
+# ConfigMap lands in `default` and collides with the copy declared there.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 resources:
   - ./k8s-cluster-info.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/actions-runner-system/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: actions-runner-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./actions-runner-controller.yaml
   - ./actions-infra-runner.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/actions-runner-system/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./actions-runner-controller.yaml
   - ./actions-infra-runner.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/cert-manager/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./cert-manager.yaml
   - ./external-secrets.yaml
   - ./issuers.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/cert-manager/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./cert-manager.yaml
   - ./external-secrets.yaml
   - ./issuers.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/cloudflared/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/cloudflared/kustomization.yaml
@@ -5,5 +5,6 @@ namespace: cloudflared
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./cloudflare-tunnel.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/cloudflared/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/cloudflared/kustomization.yaml
@@ -3,8 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cloudflared
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./cloudflare-tunnel.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/db/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/db/kustomization.yaml
@@ -7,17 +7,6 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  # Declares this namespace's copy of k8s-cluster-info rather than relying on
-  # Reflector to create it at runtime. Flux resolves postBuild.substituteFrom
-  # only in the Kustomization's own namespace, so every namespace needs a copy;
-  # Reflector's is invisible to anything that renders the repo statically, which
-  # is why konflate/flate could not render anything in here.
-  #
-  # Same file the `default` copy uses, so the values cannot drift. Reflector
-  # still writes its own copy alongside for now — the two coexist because they
-  # claim disjoint fields (Flux owns `data`, Reflector owns its annotations),
-  # verified on the konflate namespace. The Reflector source annotations come
-  # off once every namespace declares its own copy.
   - ../_shared/cluster-info
   - ./cloudnative-pg.yaml
   - ./dragonfly-operator.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/db/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/db/kustomization.yaml
@@ -7,5 +7,17 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  # Declares this namespace's copy of k8s-cluster-info rather than relying on
+  # Reflector to create it at runtime. Flux resolves postBuild.substituteFrom
+  # only in the Kustomization's own namespace, so every namespace needs a copy;
+  # Reflector's is invisible to anything that renders the repo statically, which
+  # is why konflate/flate could not render anything in here.
+  #
+  # Same file the `default` copy uses, so the values cannot drift. Reflector
+  # still writes its own copy alongside for now — the two coexist because they
+  # claim disjoint fields (Flux owns `data`, Reflector owns its annotations),
+  # verified on the konflate namespace. The Reflector source annotations come
+  # off once every namespace declares its own copy.
+  - ../_shared/cluster-info
   - ./cloudnative-pg.yaml
   - ./dragonfly-operator.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/db/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/db/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: db
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./cloudnative-pg.yaml
   - ./dragonfly-operator.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
@@ -9,8 +9,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
+components:
+  - ../_shared/cluster-info
 resources:
   - ./app-template.yaml
-  - ../_shared/cluster-info
   - ./k8s-cluster-secrets.yaml
   - ./namespace.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
@@ -1,5 +1,11 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+#
+# No Reflector patch on k8s-cluster-info any more: every namespace on this
+# cluster declares its own copy, so `default` is just another consumer rather
+# than a replication source. k8s-cluster-secrets is still reflected — the
+# flux-post-build-variables component lists it for every namespace, and only
+# `default` declares it.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
@@ -8,20 +14,3 @@ resources:
   - ../_shared/cluster-info
   - ./k8s-cluster-secrets.yaml
   - ./namespace.yaml
-patches:
-  # Only the `default` copy is a Reflector source. Namespaces that declare
-  # k8s-cluster-info themselves pull in the same shared directory without these
-  # annotations, so they get a plain ConfigMap rather than a competing
-  # auto-reflect source. Delete this patch once every namespace declares its
-  # own copy and Reflector is out of the loop entirely.
-  - target:
-      kind: ConfigMap
-      name: k8s-cluster-info
-    patch: |
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: k8s-cluster-info
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/kubernetes/clusters/fairy-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: envoy-ai-gateway-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./envoy-ai-gateway.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: envoy-ai-gateway-system
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./envoy-ai-gateway.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/envoy-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/envoy-gateway-system/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: envoy-gateway-system
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./envoy-gateway.yaml
   - ./envoy-gateway-crds.yaml
   - ./gateway-api.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/envoy-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/envoy-gateway-system/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: envoy-gateway-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./envoy-gateway.yaml
   - ./envoy-gateway-crds.yaml
   - ./gateway-api.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/external-dns/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/external-dns/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-dns
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./cloudflare.yaml
   - ./cloudflare-tunnel.yaml
   - ./external-secrets.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/external-dns/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/external-dns/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./cloudflare.yaml
   - ./cloudflare-tunnel.yaml
   - ./external-secrets.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/external-secrets/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./onepassword-connect.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/external-secrets/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./onepassword-connect.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/flux-system/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./flux-instance.yaml
   - ./flux-operator.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/flux-system/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./flux-instance.yaml
   - ./flux-operator.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/freckle-id/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/freckle-id/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./lldap.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/freckle-id/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/freckle-id/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: freckle-id
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./lldap.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gateway-system/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: gateway-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./gateways.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gateway-system/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: gateway-system
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./gateways.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/kustomization.yaml
@@ -1,9 +1,11 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
-# Cluster-scoped resources only — no `namespace:` transformer.
+# Cluster-scoped resources only — no `namespace:` transformer, which is why
+# this one does NOT take the _shared/cluster-info component every other
+# directory here does. With no transformer the ConfigMap would render without a
+# namespace, land in `default`, and collide with the copy declared there.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../_shared/cluster-info
   - ./clustersecretstore.yaml
   - ./clusterexternalsecret.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/kustomization.yaml
@@ -4,5 +4,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../_shared/cluster-info
   - ./clustersecretstore.yaml
   - ./clusterexternalsecret.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/golink/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/golink/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./golink.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/golink/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/golink/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: golink
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./golink.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/kustomization.yaml
@@ -6,5 +6,6 @@ namespace: gpu-operator
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./nvidia-gpu-operator.yaml
   - ./dra-driver-nvidia-gpu.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/kustomization.yaml
@@ -4,8 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: gpu-operator
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./nvidia-gpu-operator.yaml
   - ./dra-driver-nvidia-gpu.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/harvest/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/harvest/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: harvest
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./harvest.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/harvest/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/harvest/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: harvest
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./harvest.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/home-automation/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/home-automation/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - esphome.yaml
   # disabled for now
   # - homeassistant.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/home-automation/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/home-automation/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: home-automation
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - esphome.yaml
   # disabled for now
   # - homeassistant.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: inference
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./ai-gateway.yaml
   - ./ai-routes.yaml
   - ./external-secrets.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/inference/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/inference/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: inference
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./ai-gateway.yaml
   - ./ai-routes.yaml
   - ./external-secrets.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/janet-mcp/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet-mcp/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: janet-mcp
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./mcp.yaml
   - ./brave-search.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/janet-mcp/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet-mcp/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: janet-mcp
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./mcp.yaml
   - ./brave-search.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 # topology (deploy/flux/). The per-component child KSs (migrate/brain/
 # controller) moved into the app bundle — see janet-bootstrap.yaml.
 resources:
+  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./platform.yaml
   - ./db.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/janet/kustomization.yaml
@@ -4,12 +4,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: janet
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 # Floor (infra-owned) + the single bootstrap KS that points at the app-owned
 # topology (deploy/flux/). The per-component child KSs (migrate/brain/
 # controller) moved into the app bundle — see janet-bootstrap.yaml.
 resources:
-  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./platform.yaml
   - ./db.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/konflate/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/konflate/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: konflate
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
@@ -17,7 +18,6 @@ resources:
   #
   # Same file as the `default` copy, so the values cannot drift; the namespace
   # comes from the `namespace:` transformer above.
-  - ../_shared/cluster-info
   # SA + gcp-sm SecretStore the konflate-webhook ExternalSecret reads through.
   - ./external-secrets.yaml
   - ./konflate.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/kube-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/kube-system/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./cilium.yaml
   - ./descheduler.yaml
   - ./dranet.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/kube-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/kube-system/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./cilium.yaml
   - ./descheduler.yaml
   - ./dranet.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/minecraft/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/minecraft/kustomization.yaml
@@ -7,5 +7,6 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./minecraft-base.yaml
   - ./minecraft-servers.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/minecraft/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/minecraft/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: minecraft
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./minecraft-base.yaml
   - ./minecraft-servers.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/netdisco/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/netdisco/kustomization.yaml
@@ -5,4 +5,8 @@ namespace: netdisco
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  # See the note in ../db/kustomization.yaml — same reasoning. netdisco alone is
+  # not enough: netdisco-apps dependsOn db/cloudnative-pg, so it stayed blocked
+  # transitively until `db` declared its copy too.
+  - ../_shared/cluster-info
   - ./netdisco.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/netdisco/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/netdisco/kustomization.yaml
@@ -5,8 +5,5 @@ namespace: netdisco
 components:
   - ../../../../components/flux-post-build-variables
 resources:
-  # See the note in ../db/kustomization.yaml — same reasoning. netdisco alone is
-  # not enough: netdisco-apps dependsOn db/cloudnative-pg, so it stayed blocked
-  # transitively until `db` declared its copy too.
   - ../_shared/cluster-info
   - ./netdisco.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/netdisco/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/netdisco/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: netdisco
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./netdisco.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/networking/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/networking/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: networking
-resources:
+components:
   - ../_shared/cluster-info
+resources:
   - ./multus-trusted.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/networking/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/networking/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: networking
 resources:
+  - ../_shared/cluster-info
   - ./multus-trusted.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/observability/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/observability/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./gatus.yaml
   - ./grafana-dashboards.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/observability/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/observability/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./external-secrets.yaml
   - ./gatus.yaml
   - ./grafana-dashboards.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./rook-ceph.yaml
   - ./rook-ceph-csi-drivers.yaml
   - ./rook-ceph-cluster.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/rook-ceph/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rook-ceph
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./rook-ceph.yaml
   - ./rook-ceph-csi-drivers.yaml
   - ./rook-ceph-cluster.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/spegel/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/spegel/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: spegel
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./spegel.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/spegel/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/spegel/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: spegel
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./spegel.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/system-upgrade/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./tuppr.yaml
   - ./tuppr-plans.yaml
 patches:

--- a/kubernetes/clusters/fairy-k8s01/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/system-upgrade/kustomization.yaml
@@ -4,10 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: system-upgrade
 components:
+  - ../_shared/cluster-info
   - ../../../../components/common
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./tuppr.yaml
   - ./tuppr-plans.yaml
 patches:

--- a/kubernetes/clusters/fairy-k8s01/apps/tailscale/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/tailscale/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tailscale
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
-  - ../_shared/cluster-info
   - ./tailscale-api-server-proxy.yaml
   - ./tailscale-operator.yaml
   - ./tailscale-proxyclass.yaml

--- a/kubernetes/clusters/fairy-k8s01/apps/tailscale/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/tailscale/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: tailscale
 components:
   - ../../../../components/flux-post-build-variables
 resources:
+  - ../_shared/cluster-info
   - ./tailscale-api-server-proxy.yaml
   - ./tailscale-operator.yaml
   - ./tailscale-proxyclass.yaml


### PR DESCRIPTION
Completes the cluster-info rollout for **fairy** and retires Reflector from this ConfigMap on that cluster. atlantis is untouched.

## Why

Flux resolves `postBuild.substituteFrom` only in the Kustomization's **own** namespace, so every namespace needs its own copy of `k8s-cluster-info`. Reflector made those at runtime — which worked, but was invisible to anything rendering the repo statically. konflate/flate couldn't render most of fairy, so a PR touching those namespaces showed an **empty diff rather than a wrong one**, which is the quiet failure mode worth fixing.

## What changed

- All **30** fairy namespaces now pull the copy from `apps/_shared/cluster-info` — same file, so values can't drift
- With every namespace covered, `default` stops being a replication source and the Reflector patch comes off
- `k8s-cluster-secrets` **keeps** its reflection: the `flux-post-build-variables` component lists it for every namespace and only `default` declares it

## Measured

| flate on fairy | before | after |
|---|---|---|
| passed | 123 | **204** |
| blocked | 52 | **1** |

The one remaining is `janet/janet`, blocked by its private-registry OCIRepository — unrelated and pre-existing.

Every fairy namespace kustomization builds, the `cluster-apps` root builds, and zero `k8s-cluster-info` blocks remain.

## The hedgehog check

#2233 broke `hedgehog` because a Kustomization sourced from an **OCI bundle** substitutes variables this repo can't see, and Flux substitution is strict — a missing key fails the whole Kustomization rather than rendering empty. A repo-wide grep structurally cannot catch that.

Applied that lesson here: fairy's OCI-sourced Kustomizations are `janet` and `default`, and **both are covered**.

## Reflector handover

Flux and Reflector coexisted during the transition rather than fighting — server-side apply gives them disjoint claims (Flux owns `data`, Reflector owns its annotations), verified on konflate where `resourceVersion` held flat. Now that every fairy namespace declares its own copy, Reflector is simply out of the loop for this ConfigMap on fairy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide Flux/GitOps surface on fairy (many namespaces) around post-build substitution, but ConfigMap content is shared and behavior should match Reflector copies; wrong wiring could fail Kustomization reconciliation until fixed.
> 
> **Overview**
> On **fairy-k8s01**, every namespace-scoped app kustomization now includes the shared `../_shared/cluster-info` **kustomize Component** (alongside `flux-post-build-variables` where it already lived), so each namespace gets its own `k8s-cluster-info` ConfigMap in git instead of relying on Reflector at runtime. That makes static tools like flate/konflate see the map in the same namespace Flux uses for `postBuild.substituteFrom`.
> 
> The shared `apps/_shared/cluster-info` bundle is reclassified from `kind: Kustomization` to **`kind: Component`**, with comments explaining why cluster-scoped dirs such as `ghcr-pull` must not include it (no namespace transformer → collision in `default`).
> 
> On fairy **`default`**, the Reflector source annotations on `k8s-cluster-info` are **removed**—`default` is no longer the replication hub—and `k8s-cluster-info` is wired via `components` instead of `resources`. **`k8s-cluster-secrets`** still follows the old Reflector pattern via `flux-post-build-variables`.
> 
> **atlantis-k8s01** gets the same Component conversion and moves `cluster-info` under `components` for `default` and `konflate` (Reflector patch on atlantis `default` is unchanged in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21adeb98c657ea3c95967ec2a95b803fe4b5eca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->