### PR TITLE
fix(flux): restore Reflector as the fallback for k8s-cluster-info on fairy

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
@@ -1,15 +1,6 @@
 ---
-# The cluster's postBuild substitution variables.
-#
-# Flux resolves `postBuild.substituteFrom` only in the Kustomization's own
-# namespace, so a copy of this has to exist in every namespace that substitutes.
-# Reflector still makes most of those copies at runtime — the annotations that
-# drive it are applied by a patch in ../../default/kustomization.yaml rather
-# than living here, so that namespaces pulling this in directly (see
-# ../../konflate/) get a plain ConfigMap and not a second auto-reflect source.
-#
-# Once every namespace declares its own copy, the patch goes away and Reflector
-# stops being involved in this ConfigMap at all.
+# Flux resolves postBuild.substituteFrom only in the Kustomization's own
+# namespace, so every namespace needs a copy. Shared so they cannot drift.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/_shared/cluster-info/kustomization.yaml
@@ -1,18 +1,8 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 #
-# A kustomize Component, not a namespace: it is listed under `components:` by
-# every namespace on this cluster, alongside flux-post-build-variables, and no
-# Flux Kustomization points at it directly.
-#
-# It exists because Flux resolves postBuild.substituteFrom only in the
-# Kustomization's own namespace, so each namespace needs its own copy of
-# k8s-cluster-info. Sharing one file keeps the values from drifting.
-#
-# Deliberately carries no `namespace:` — the including kustomization's own
-# namespace transformer places the ConfigMap. A kustomization with no such
-# transformer (cluster-scoped dirs like ghcr-pull) must NOT include this, or the
-# ConfigMap lands in `default` and collides with the copy declared there.
+# Only include this from a kustomization that sets `namespace:` — without one
+# the ConfigMap renders namespaceless and lands in `default`.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/k8s-cluster-info.yaml
@@ -1,15 +1,6 @@
 ---
-# The cluster's postBuild substitution variables.
-#
-# Flux resolves `postBuild.substituteFrom` only in the Kustomization's own
-# namespace, so a copy of this has to exist in every namespace that substitutes.
-# Reflector still makes most of those copies at runtime — the annotations that
-# drive it are applied by a patch in ../../default/kustomization.yaml rather
-# than living here, so that namespaces pulling this in directly (see
-# ../../konflate/) get a plain ConfigMap and not a second auto-reflect source.
-#
-# Once every namespace declares its own copy, the patch goes away and Reflector
-# stops being involved in this ConfigMap at all.
+# Flux resolves postBuild.substituteFrom only in the Kustomization's own
+# namespace, so every namespace needs a copy. Shared so they cannot drift.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/kustomization.yaml
@@ -1,27 +1,8 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 #
-# A kustomize Component, not a namespace: it is listed under `components:` by
-# every namespace on this cluster, alongside flux-post-build-variables, and no
-# Flux Kustomization points at it directly.
-#
-# It exists because Flux resolves postBuild.substituteFrom only in the
-# Kustomization's own namespace, so each namespace needs its own copy of
-# k8s-cluster-info. Sharing one file keeps the values from drifting.
-#
-# Declaring the copies here is what lets flate/konflate render these namespaces
-# at all — Reflector's runtime copies are invisible to anything reading the
-# repo. Reflector still runs as the fallback for namespaces that exist on the
-# cluster but not in git; see ../../default/kustomization.yaml.
-#
-# No `kustomize.toolkit.fluxcd.io/ssa: Merge` here, though d1-fleet uses it for
-# the same coexistence: Merge would also stop Flux from ever removing a key we
-# delete from this file, and the two writers were measured not to contend.
-#
-# Deliberately carries no `namespace:` — the including kustomization's own
-# namespace transformer places the ConfigMap. A kustomization with no such
-# transformer (cluster-scoped dirs like ghcr-pull) must NOT include this, or the
-# ConfigMap lands in `default` and collides with the copy declared there.
+# Only include this from a kustomization that sets `namespace:` — without one
+# the ConfigMap renders namespaceless and lands in `default`.
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/_shared/cluster-info/kustomization.yaml
@@ -9,6 +9,15 @@
 # Kustomization's own namespace, so each namespace needs its own copy of
 # k8s-cluster-info. Sharing one file keeps the values from drifting.
 #
+# Declaring the copies here is what lets flate/konflate render these namespaces
+# at all — Reflector's runtime copies are invisible to anything reading the
+# repo. Reflector still runs as the fallback for namespaces that exist on the
+# cluster but not in git; see ../../default/kustomization.yaml.
+#
+# No `kustomize.toolkit.fluxcd.io/ssa: Merge` here, though d1-fleet uses it for
+# the same coexistence: Merge would also stop Flux from ever removing a key we
+# delete from this file, and the two writers were measured not to contend.
+#
 # Deliberately carries no `namespace:` — the including kustomization's own
 # namespace transformer places the ConfigMap. A kustomization with no such
 # transformer (cluster-scoped dirs like ghcr-pull) must NOT include this, or the

--- a/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
@@ -1,11 +1,19 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 #
-# No Reflector patch on k8s-cluster-info any more: every namespace on this
-# cluster declares its own copy, so `default` is just another consumer rather
-# than a replication source. k8s-cluster-secrets is still reflected — the
-# flux-post-build-variables component lists it for every namespace, and only
-# `default` declares it.
+# `default` holds the Reflector source copy of k8s-cluster-info. Every namespace
+# in git also declares its own copy via the _shared/cluster-info component, so
+# Reflector is no longer how the ConfigMap gets delivered — it is the fallback
+# for namespaces that exist on the cluster but not in this repo (hand-made ones
+# like nicole-dev or benchmark), which would otherwise have nothing.
+#
+# Both mechanisms run at once and do not fight: server-side apply gives them
+# disjoint claims, Flux owning `data` and Reflector owning its own annotations.
+# Verified on konflate, where resourceVersion stayed flat with both active.
+#
+# The annotations live here as a patch rather than in the shared component so
+# that only this copy is a replication source; the copies in other namespaces
+# are plain ConfigMaps and cannot become sources themselves.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
@@ -15,3 +23,15 @@ resources:
   - ./app-template.yaml
   - ./k8s-cluster-secrets.yaml
   - ./namespace.yaml
+patches:
+  - target:
+      kind: ConfigMap
+      name: k8s-cluster-info
+    patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: k8s-cluster-info
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/default/kustomization.yaml
@@ -1,19 +1,9 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
 #
-# `default` holds the Reflector source copy of k8s-cluster-info. Every namespace
-# in git also declares its own copy via the _shared/cluster-info component, so
-# Reflector is no longer how the ConfigMap gets delivered — it is the fallback
-# for namespaces that exist on the cluster but not in this repo (hand-made ones
-# like nicole-dev or benchmark), which would otherwise have nothing.
-#
-# Both mechanisms run at once and do not fight: server-side apply gives them
-# disjoint claims, Flux owning `data` and Reflector owning its own annotations.
-# Verified on konflate, where resourceVersion stayed flat with both active.
-#
-# The annotations live here as a patch rather than in the shared component so
-# that only this copy is a replication source; the copies in other namespaces
-# are plain ConfigMaps and cannot become sources themselves.
+# The patch makes only this copy a Reflector source. Every namespace in git
+# declares its own copy via the component, so Reflector is just the fallback for
+# namespaces that exist on the cluster but not in this repo.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default

--- a/kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/ghcr-pull/kustomization.yaml
@@ -1,9 +1,7 @@
 ---
 # yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
-# Cluster-scoped resources only — no `namespace:` transformer, which is why
-# this one does NOT take the _shared/cluster-info component every other
-# directory here does. With no transformer the ConfigMap would render without a
-# namespace, land in `default`, and collide with the copy declared there.
+# Cluster-scoped resources only — no `namespace:` transformer, so it must not
+# take the _shared/cluster-info component.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
Puts the Reflector source annotations back on fairy's `default` copy of `k8s-cluster-info`. The per-namespace declarations from #2245 stay exactly as they are.

## Why

#2245 removed the annotations once every namespace in git declared its own copy. That was a step too far — Reflector was doing **two** jobs and only one had been replaced:

1. **Delivering** the ConfigMap → now done from git, and better, because a declared copy is visible to anything rendering the repo
2. **Auto-populating hand-made namespaces** → nothing replaced this

Losing (2) means a namespace created outside git (`nicole-dev`, `benchmark`, …) silently has no `k8s-cluster-info`. Only Kustomizations that *opt in* are affected — the `flux-post-build-variables` component patches `substituteFrom` onto Kustomizations carrying the label, so anything unlabelled is unaffected either way.

## What it cost the first time

Removing the annotations triggered a **one-time cleanup pass** in Reflector:

```
Source default/k8s-cluster-info no longer permits the auto reflection to
observability/k8s-cluster-info. Deleting observability/k8s-cluster-info.
```

It deleted every mirror — including in namespaces Flux had just applied its own copy into. Eight Kustomizations went down (`cilium`, `flux-instance`, `envoy-gateway`, both `external-dns`, `actions-infra-runner`, `netdisco`, and `networking-apps` which timed out its health check waiting on a ConfigMap deleted from under it). All recovered after forced reconciles.

## The arrangement now

Reflector's role changes rather than returning as-was: it is **no longer how the ConfigMap is delivered**, only the fallback for namespaces not in git. The git declarations stay and remain the reason konflate can render fairy at all.

Both run at once without contending — server-side apply gives them disjoint claims, Flux owning `data` and Reflector owning its annotations. Measured on konflate: `resourceVersion` flat with both active.

The annotations stay as a patch in `default` rather than in the shared component, so only that copy is a replication source and the other namespaces' copies can't become sources themselves.

## Not adopting `ssa: Merge`

[d1-fleet](https://github.com/controlplaneio-fluxcd/d1-fleet) uses `kustomize.toolkit.fluxcd.io/ssa: "Merge"` for this same coexistence (they propagate with Kyverno instead of Reflector — same architecture, different tool). Skipped here: Merge would also stop Flux ever removing a key deleted from the shared file, and the two writers were measured not to contend without it.

## Verified

- Only `default` renders as a Reflector source; all other namespaces get plain ConfigMaps
- fairy flate unchanged: **204 passed / 1 blocked** (the 1 is `janet`, private registry)
- atlantis never had the annotations removed, so it is already in this state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Flux post-build substitution and Reflector lifecycle on a live cluster; misconfiguration could repeat mirror deletion or leave off-repo namespaces without cluster-info, though the change aligns fairy with atlantis and keeps annotations off non-default copies.
> 
> **Overview**
> Restores **Reflector auto-reflection** on fairy’s `default/k8s-cluster-info` by adding a kustomize patch with `reflection-allowed` and `reflection-auto-enabled`. Per-namespace copies from the shared `cluster-info` component stay as-is; Reflector again fills **namespaces not declared in git** (e.g. hand-made dev namespaces) so Flux post-build substitution can still find `k8s-cluster-info`.
> 
> The patch stays on **`default` only** so other namespaces’ copies are not replication sources. Comments in the shared `cluster-info` component and `ghcr-pull` are tightened to document the `namespace:` requirement and the new “git primary, Reflector fallback” model (atlantis shared files get the same comment edits; atlantis already had the Reflector patch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014f2cfe271437978e2427f36713441590e08265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->