### PR TITLE
refactor(flux): declare k8s-cluster-info per namespace on atlantis

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/actions-runner-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: actions-runner-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./actions-runner-controller.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/cert-manager/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/cert-manager/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./cert-manager.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/cloudflared/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/cloudflared/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cloudflared
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/cnpg-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/cnpg-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cnpg-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./cloudnative-pg.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/db/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/db/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: db
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./cloudnative-pg.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/democratic-csi/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/democratic-csi/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: democratic-csi
+components:
+  - ../_shared/cluster-info
 resources:
   - ./externalsecret.yaml
   - ./democratic-csi.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/envoy-ai-gateway-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: envoy-ai-gateway-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./envoy-ai-gateway.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/envoy-gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/envoy-gateway-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: envoy-gateway-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./envoy-gateway.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/external-dns/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/external-dns/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-dns
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./cloudflare.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/external-secrets/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/flux-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/freckle-id/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/freckle-id/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: freckle-id
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./pocket-id.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/garage/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/garage/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: garage
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./nas-garage.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/gateway-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/gateway-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: gateway-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./certificates.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/hedgehog/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: hedgehog
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./platform.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/homebox/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/homebox/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: homebox
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./homebox.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/it-tools/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/it-tools/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: it-tools
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./it-tools.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/kube-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/kube-system/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./cilium-cidrgroups.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/matrix/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/matrix/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: matrix
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/media/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/media/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./audiobookshelf.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/nautobot/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/nautobot/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: nautobot
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/netflow/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/netflow/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: netflow
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/observability/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/observability/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./external-secrets.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rook-ceph
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./rook-ceph.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/spegel/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/spegel/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: spegel
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./spegel.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/system-upgrade/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: system-upgrade
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./tuppr.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/tailscale/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/tailscale/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: tailscale
 components:
+  - ../_shared/cluster-info
   - ../../../../components/flux-post-build-variables
 resources:
   - ./tailscale-api-server-proxy.yaml

--- a/kubernetes/clusters/atlantis-k8s01/apps/volsync-system/kustomization.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/volsync-system/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: volsync-system
+components:
+  - ../_shared/cluster-info
 resources:
   - ./volsync.yaml


### PR DESCRIPTION
Mirrors the fairy rollout (#2245) onto atlantis. **Purely additive** — Reflector keeps its source annotations and its fallback role.

## What it does

Adds the `_shared/cluster-info` component to the 28 atlantis namespaces that didn't already have it, so each declares its own copy of `k8s-cluster-info` rather than depending on Reflector's runtime copy — which is invisible to anything rendering the repo, and is why konflate couldn't render most of atlantis.

## Measured

| flate on atlantis | before | after |
|---|---|---|
| passed | 251 | **342** |
| blocked | 52 | **1** |

Zero `k8s-cluster-info` blocks remain. The one left is `janet/janet`, blocked by its private-registry OCIRepository — unrelated and pre-existing.

## Not repeating the fairy mistake

Fairy's rollout also **removed** the Reflector source annotations. That triggered a one-time cleanup pass which deleted every mirror — including in namespaces Flux had just applied its own copy into — and took eight Kustomizations down until the next reconcile (#2246 put it back).

That step is deliberately **not** done here. Reflector stays as the fallback for namespaces that exist on the cluster but aren't in git.

## Trap checks

- **ghcr-pull class**: all 28 namespaces carry a `namespace:` transformer, so none render the ConfigMap namespaceless into `default`. Verified: 0 namespaceless copies, and `default` is still the only Reflector source.
- **hedgehog class**: OCI-sourced Kustomizations substitute variables this repo can't grep and Flux substitution is strict — that's what broke hedgehog in #2233. On atlantis those are `hedgehog` and `default`, and **both are covered**.

## Known cosmetic issue

konflate has been reporting ~52 phantom "failures" since the fairy rollout — a fabricated dependency cycle (`netdisco-apps` ↔ `db/cloudnative-pg`) that exists nowhere in the repo. Likely flate resolving "which Kustomization produces `k8s-cluster-info`" without namespace scoping, now that there are 30 identically-named copies. Cluster is unaffected (fairy is 113/113 Ready); tracking separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Kustomize component wiring only; no app logic or Reflector teardown. Flux will apply additional per-namespace ConfigMaps that should match existing reflected copies.
> 
> **Overview**
> Rolls out the same **per-namespace `k8s-cluster-info` pattern** used on fairy to **atlantis-k8s01**: **28** app `kustomization.yaml` files now include the `../_shared/cluster-info` component so each namespace renders its own `k8s-cluster-info` ConfigMap in git, instead of relying only on Reflector mirrors that offline tools cannot see.
> 
> Namespaces that already had `flux-post-build-variables` only add the new component line; **`democratic-csi`** and **`volsync-system`** introduce a `components:` block for the first time. **Reflector source annotations are not removed** here—Reflector remains the fallback for cluster namespaces not in git.
> 
> This is aimed at fixing konflate/flate rendering (e.g. clearing `k8s-cluster-info`-related blocks on atlantis) while avoiding the fairy incident where removing Reflector annotations deleted mirrors and broke reconciles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ade73809b374ded85838dee002246d606e2b435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->