### PR TITLE
feat(fairy): add infra-private as a second Flux source

### DIFF
--- a/kubernetes/clusters/fairy-k8s01/apps/flux-system/infra-private-externalsecret.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/flux-system/infra-private-externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# SSH deploy-key Secret for the `infra-private` GitRepository (see
+# infra-private.yaml). Read-only key for freckleapps/infra; source-controller
+# uses it to clone + poll that repo.
+#
+# The GSM secret holds a JSON blob { identity, known_hosts }; this renders it
+# into the key shape source-controller's SSH auth expects: `identity` (the
+# private key) and `known_hosts` (host-key pin, so a MITM can't impersonate
+# github.com). No `identity.pub` needed for clone.
+#
+# fairy-only: the per-secret IAM grant (tofu flux-infra-private.tf) authorizes
+# just the fairy flux-system ESO SA, and this file lives under the fairy
+# cluster dir — atlantis never renders it. The two clusters use SEPARATE keys
+# and SEPARATE GSM secrets so either can be revoked without touching the other.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: infra-private-deploy-key
+  namespace: flux-system
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: gcp-sm
+  target:
+    name: infra-private-deploy-key
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        identity: "{{ .identity }}"
+        known_hosts: "{{ .known_hosts }}"
+  dataFrom:
+    - extract:
+        key: fairy-k8s01-flux-infra-private-deploy-key

--- a/kubernetes/clusters/fairy-k8s01/apps/flux-system/infra-private.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/flux-system/infra-private.yaml
@@ -1,0 +1,47 @@
+---
+# Second Flux source for fairy-k8s01: the PRIVATE freckleapps/infra repo.
+# Mirrors the atlantis-k8s01 setup exactly — see that cluster's copy of this
+# file. Private workloads and site-specific network-device scrape configs live
+# there instead of in this public repo. See that repo's CLAUDE.md.
+#
+# SSH (not the flux-system GitHub App) so the credential is a scoped, read-only
+# deploy key on that one repo — the App's blast radius is the whole org.
+# The key is DISTINCT from atlantis's: GitHub rejects the same public key as a
+# deploy key on a repo twice, and a per-cluster key keeps revocation granular.
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: infra-private
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: ssh://git@github.com/freckleapps/infra.git
+  ref:
+    branch: main
+  secretRef:
+    name: infra-private-deploy-key
+---
+# Root Kustomization for the private source — the analogue of the FluxInstance's
+# spec.sync for flux-system, but as a plain Kustomization since the operator
+# manages only the primary source. Points at the private repo's fairy flux
+# dir, which fans out to its own namespace + app Kustomizations (all of which
+# must carry sourceRef: infra-private — CI in that repo enforces it).
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-private
+  namespace: flux-system
+spec:
+  targetNamespace: flux-system
+  sourceRef:
+    kind: GitRepository
+    name: infra-private
+    namespace: flux-system
+  path: ./kubernetes/clusters/fairy-k8s01/flux
+  interval: 10m
+  retryInterval: 2m
+  timeout: 5m
+  prune: true
+  wait: false

--- a/kubernetes/clusters/fairy-k8s01/apps/flux-system/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/flux-system/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - ./external-secrets.yaml
   - ./flux-instance.yaml
   - ./flux-operator.yaml
+  - ./infra-private-externalsecret.yaml
+  - ./infra-private.yaml


### PR DESCRIPTION
Mirrors the atlantis-k8s01 setup: a `GitRepository` for the private `freckleapps/infra` repo plus the root Kustomization that fans out to its fairy flux dir.

Site-specific network-device scrape configs belong in the private repo rather than here. The first one is the Firewalla Gold Pro's node-exporter — see freckleapps/infra#53.

### Credential
SSH deploy key rather than the flux-system GitHub App, so it's scoped read-only to that one repo instead of the App's org-wide blast radius. **Distinct from atlantis's key** — GitHub rejects a duplicate public key as a deploy key on the same repo, and per-cluster keys keep revocation granular. The value comes from GSM via ESO, authorized by a per-secret IAM grant to `external-secrets-fairy-k8s01` (tofu already applied).

### ⚠️ Merge order
**freckleapps/infra#53 must merge first.** The root Kustomization here points at `./kubernetes/clusters/fairy-k8s01/flux` in that repo — if the path doesn't exist yet, the Kustomization fails with an opaque path error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new GitOps credentials and a second sync path; failure modes include missing private-repo path and secret/IAM misconfiguration, but pattern is proven on atlantis and keys are isolated per cluster.
> 
> **Overview**
> **fairy-k8s01** gets a second Flux source for the private `freckleapps/infra` repo, matching the existing **atlantis-k8s01** pattern.
> 
> An **ExternalSecret** pulls a **fairy-only** SSH deploy key from GSM (`fairy-k8s01-flux-infra-private-deploy-key`) into `infra-private-deploy-key` for source-controller. A **GitRepository** `infra-private` clones that repo over SSH, and a root **Kustomization** applies `./kubernetes/clusters/fairy-k8s01/flux` from it. The flux-system app **kustomization** now includes both new manifests.
> 
> Credentials stay **scoped** (deploy key vs org-wide GitHub App) and **separate from atlantis** so revocation stays per-cluster. **Merge order:** the private repo path must exist (e.g. freckleapps/infra#53) before this Kustomization can succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a4ca5acff4ed625d18b710af250bbd0a4f9a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->