### PR TITLE
fix(flux): set flux-operator-mcp transport to http

### DIFF
--- a/kubernetes/apps/flux/mcp/helmrelease.yaml
+++ b/kubernetes/apps/flux/mcp/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
   # out of the agent's hands until we're ready to relax that.
   values:
     readonly: true
-    transport: sse
+    transport: http
     # Chart's NetworkPolicy can only filter by namespace; we want
     # pod-label scoping (only the tailnet envoy gateway pods, not all of
     # gateway-system). See cnp.yaml in this dir for the replacement.


### PR DESCRIPTION
## Problem

`Image Pull - Success` — currently the **only** required check — is failing on **every** open PR. Root cause is on `main`, not in any of the PRs:

```
flate error: reconcile completed with 1 failure(s):
  HelmRelease/flux-system/flux-operator-mcp: helm template flux-system/flux-operator-mcp:
  values don't meet the specifications of the schema(s) in the following chart(s):
  flux-operator-mcp:
  - at '/transport': value must be 'http'
```

The same failure has the live HelmRelease on `atlantis-k8s01` wedged NotReady.

## Cause

The chart dropped the deprecated MCP SSE transport. Its `values.schema.json` now constrains `transport` to a single-value enum:

```json
"transport": { "type": "string", "enum": ["http"] }
```

Verified against both the currently pinned `0.59.0` and the `0.60.0` proposed in #2372 — `sse` is rejected by both, and `http` is already the chart default.

## Fix

`transport: sse` → `transport: http`.

Unblocks the required check repo-wide and lets the atlantis HelmRelease reconcile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single values change to satisfy chart schema; aligns with the chart’s only supported transport and default.
> 
> **Overview**
> Updates the **flux-operator-mcp** `HelmRelease` so `values.transport` is **`http`** instead of the removed **`sse`** option, matching the chart schema and default.
> 
> This should let Flux reconcile the release again and clear the repo-wide Helm validation failure that was blocking the required **Image Pull - Success** check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22321bd5848d92ddef1c63e2a99f65ce215592ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->