### PR TITLE
fix(external-dns): pin the alpha annotation prefix

### DIFF
--- a/kubernetes/apps/networking/external-dns/cloudflare-tunnel/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare-tunnel/helmrelease.yaml
@@ -71,6 +71,13 @@ spec:
     txtOwnerId: "${CLUSTER_NAME}-cftun"
     txtPrefix: k8s-cftun.
     policy: sync
+    # external-dns 0.22 flips the default annotation prefix to the GA
+    # external-dns.kubernetes.io/ with NO fallback (upstream #6424). Our
+    # Gateway target, Service hostname and controller annotations all still
+    # use the alpha prefix, and policy: sync means an unrecognised annotation
+    # rewrites or deletes the record. Pin the prefix so the 0.22 bump is a
+    # no-op; migrating the annotations themselves is a separate change.
+    annotationPrefix: external-dns.alpha.kubernetes.io/
     securityContext:
       allowPrivilegeEscalation: false
       seccompProfile:

--- a/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/helmrelease.yaml
@@ -80,6 +80,13 @@ spec:
     txtOwnerId: "${CLUSTER_NAME}"
     txtPrefix: k8s-
     policy: sync
+    # external-dns 0.22 flips the default annotation prefix to the GA
+    # external-dns.kubernetes.io/ with NO fallback (upstream #6424). Our
+    # Gateway target, Service hostname and controller annotations all still
+    # use the alpha prefix, and policy: sync means an unrecognised annotation
+    # rewrites or deletes the record. Pin the prefix so the 0.22 bump is a
+    # no-op; migrating the annotations themselves is a separate change.
+    annotationPrefix: external-dns.alpha.kubernetes.io/
     securityContext:
       allowPrivilegeEscalation: false
       seccompProfile:


### PR DESCRIPTION
Prep for #2371 (external-dns chart `1.21.1 → 1.22.0`, app `v0.21.0 → v0.22.0`). **Merge this first.**

## Why

v0.22.0's release notes carry an "Action required before upgrade" ([#6424](https://github.com/kubernetes-sigs/external-dns/pull/6424)): the default annotation prefix moves to `external-dns.kubernetes.io/` **with no fallback**. Upstream's own words — *"This change can delete all your DNS records."*

Confirmed in source, it's a hard constant flip rather than a dual read:

```go
// source/annotations/annotations.go
v0.21.0: DefaultAnnotationPrefix = "external-dns.alpha.kubernetes.io/"
v0.22.0: DefaultAnnotationPrefix = "external-dns.kubernetes.io/"
```

Both our instances run `policy: sync`, so an unrecognised annotation doesn't degrade gracefully.

## What would break

A sweep of both clusters across Gateways, HTTPRoutes, GRPCRoutes, TLSRoutes, Services, Ingresses and DNSEndpoints found four live load-bearing alpha-prefixed annotations:

| Object | Annotation | Impact |
|---|---|---|
| `gateway-system/tunnel` Gateway (both clusters) | `target` | **Critical.** Falls back to the Gateway's status addresses — ClusterIPs for the `envoy-clusterip` class. Every tunnelled CNAME becomes an A record pointing at a cluster-internal IP. 4 HTTPRoutes on fairy, 2 on atlantis. |
| `minecraft/hogwarts-minecraft` + `-public` Services (fairy) | `hostname` | Service source yields no hostname → records **deleted** under `policy: sync`. |
| `gateway-system/httpsredirect` HTTPRoute (both) | `controller: none` | Exclusion stops working. Low practical risk (no hostnames on the route or its listeners), but fix anyway. |

## Why this is a no-op today

`annotationPrefix` is a first-class chart value in the **currently pinned** 1.21.1 (`values.yaml:259`, rendering `--annotation-prefix` at `templates/deployment.yaml:132-133`), and the value set here is exactly 0.21's built-in default. So nothing changes on-cluster now — it just makes the 0.22 bump a no-op too.

Migrating the annotations themselves to the GA prefix is deliberately left as a separate change; it can't be pre-staged because 0.21 doesn't recognise the GA prefix at all.

## Verify after merge

`--annotation-prefix=external-dns.alpha.kubernetes.io/` present in the live args of both instances on both clusters, before #2371 goes in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that preserves today’s effective defaults and reduces DNS deletion risk on the upcoming external-dns bump.
> 
> **Overview**
> **Pins `annotationPrefix` to `external-dns.alpha.kubernetes.io/`** on both Cloudflare external-dns HelmReleases (standard and tunnel), with inline notes tying this to external-dns **0.22** defaulting to the GA `external-dns.kubernetes.io/` prefix with no fallback.
> 
> That keeps behavior unchanged on the current chart while avoiding a dangerous upgrade: with **`policy: sync`**, ignored annotations can rewrite or delete DNS for Gateways, Services, and routes that still use the alpha keys (e.g. tunnel Gateway `target`, minecraft `hostname`, redirect `controller: none`). Migrating those annotations to GA is explicitly deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd74fee4fd058b437aedb5d81ae4454d76c7d941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->