### PR TITLE
fix(rook-ceph): skip upgrade checks on atlantis to finish the OSD roll

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
@@ -31,3 +31,16 @@ spec:
       patch: |-
         - op: remove
           path: /spec/values/cephClusterSpec/storage/encryptedDevice
+        # TEMPORARY — remove once the OSDs are all on 20.2.4.
+        # Ceph 20.2.4 added the CVE-2025-30156 CephX audit, which puts this
+        # cluster in HEALTH_ERR because every daemon key is still the legacy
+        # aes type. Rook refuses to upgrade a cluster in HEALTH_ERR, so the 9
+        # OSDs are stranded on 20.2.2 while mon/mgr/mds/rgw are on 20.2.4 —
+        # and the HEALTH_ERR is itself caused by those OSDs' keys, so it
+        # cannot clear on its own. The stalled CephCluster also fails the
+        # HelmRelease, which blocks ~22 dependent Kustomizations.
+        # Data is healthy (265 PGs active+clean, 9/9 OSDs up/in), so the only
+        # thing this check is blocking on is the auth audit.
+        - op: add
+          path: /spec/values/cephClusterSpec/skipUpgradeChecks
+          value: true


### PR DESCRIPTION
## Problem

atlantis-k8s01's Ceph upgrade has been stalled for **six days**. Mons, mgrs, MDSs and RGW are on 20.2.4; all 9 OSDs are still on 20.2.2:

```
rook-ceph-osd-0..8                 quay.io/ceph/ceph:v20.2.2   (last updated 2026-07-19)
rook-ceph-mon/mgr/mds/rgw          quay.io/ceph/ceph:v20.2.4   (2026-09-06)
```

Rook retries every ~17 minutes and refuses every time:

```
W | cluster-controller: it looks like we have more than one ceph version running. triggering upgrade.
    map[20.2.2:9  20.2.4:8]
E | cluster-controller: failed the ceph version check: ceph status in namespace rook-ceph is not
    healthy, refusing to upgrade. Either fix the health issue or force an update by setting
    skipUpgradeChecks to true in the cluster CR
```

## Why it cannot resolve itself

The health error is entirely the CephX key-type audit 20.2.4 added for [CVE-2025-30156](https://docs.ceph.com/en/latest/security/CVE-2025-30156/):

```
[ERR] AUTH_INSECURE_SERVICE_KEY_TYPE: 13 auth service entities with insecure key types
[ERR] AUTH_INSECURE_SERVICE_TICKETS: Monitors are configured to issue insecure service tickets
```

It is circular:

- The 9 OSDs' own keys are among the 13 entities tripping the audit.
- Rook won't upgrade a `HEALTH_ERR` cluster, so they stay on 20.2.2.
- Rotating keys first doesn't help — a 20.2.2 OSD predates `aes256k` entirely and would be unable to authenticate. Rotation invalidates the old key immediately.

## Why fairy is fine and atlantis isn't

Both clusters ran this upgrade in the same window and reached the *identical* state:

```
fairy    02:07:31  disabling cephx key rotation because desired ceph image version "20.2.4-0"
atlantis 02:08:44  supports AES256K keys, but at least one OSD (low version "20.2.2-0") does not
```

Rook upgrades OSDs last. Fairy got them done inside a single reconcile pass that had already cleared the health gate (`02:13:03 successfully upgraded cluster to version: "20.2.4-0 tentacle"`). Atlantis's operator restarted at `02:10:33` with its OSDs still pending; the fresh pass re-ran the gate and saw the error the newly-upgraded mons had just started reporting.

Same Rook v1.20.7, same Ceph v20.2.4, same Talos generation. **A race atlantis lost by about a minute** — not a configuration difference.

## Blast radius of leaving it

The stalled CephCluster fails the HelmRelease (`timeout waiting for: [CephCluster/rook-ceph/rook-ceph status: 'InProgress']`), which blocks **~22 dependent Kustomizations** behind `dependency 'rook-ceph/rook-ceph-cluster' is not ready` — most of `media`, plus `netflow/clickhouse`, `netflow/kafka` and `observability/gatus`. The apps are running, but no change to any of them can reconcile on atlantis.

## Safety

Data is healthy and has been throughout — **265 PGs `active+clean`, 9/9 OSDs up/in**, confirmed both now and in the operator's own status dump at the moment it first refused. The only thing the gate is blocking on is the auth audit.

Scoped to the atlantis pointer rather than the shared app dir so fairy keeps its health gate.

## Follow-up (required)

**Revert this as soon as the OSDs report 20.2.4.** Leaving it on disarms the gate for genuine problems — degraded PGs, OSDs down, mons out of quorum — on the next Ceph bump. Key rotation to `aes256k` is tracked separately; it can't proceed past the daemon keys until Talos ships a 7.0+ kernel for the CSI path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Temporarily disables Rook’s pre-upgrade health gate on production Ceph for atlantis; data path is reported healthy but future upgrades won’t be blocked by genuine cluster health issues until reverted.
> 
> **Overview**
> Adds a **temporary** Flux JSON patch on **atlantis-k8s01** only that sets `cephClusterSpec.skipUpgradeChecks: true` on the `rook-ceph-cluster` HelmRelease, so Rook can finish upgrading the nine OSDs still on Ceph 20.2.2 while the rest of the cluster is on 20.2.4.
> 
> The patch is documented as a one-off workaround for a circular **HEALTH_ERR** from Ceph 20.2.4’s CephX key audit (CVE-2025-30156): Rook refuses upgrades while unhealthy, but the audit won’t clear until those OSDs upgrade. Unblocking the upgrade should also clear the stalled CephCluster/HelmRelease and ~22 Flux Kustomizations that depend on `rook-ceph-cluster`. **Revert once all OSDs are on 20.2.4** so normal upgrade health gates apply again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e78d4cda57d19e930701759c3e4f34d31013f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->