### PR TITLE
fix(rook-ceph): re-arm the upgrade health gate on atlantis

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/rook-ceph/rook-ceph-cluster.yaml
@@ -31,16 +31,3 @@ spec:
       patch: |-
         - op: remove
           path: /spec/values/cephClusterSpec/storage/encryptedDevice
-        # TEMPORARY — remove once the OSDs are all on 20.2.4.
-        # Ceph 20.2.4 added the CVE-2025-30156 CephX audit, which puts this
-        # cluster in HEALTH_ERR because every daemon key is still the legacy
-        # aes type. Rook refuses to upgrade a cluster in HEALTH_ERR, so the 9
-        # OSDs are stranded on 20.2.2 while mon/mgr/mds/rgw are on 20.2.4 —
-        # and the HEALTH_ERR is itself caused by those OSDs' keys, so it
-        # cannot clear on its own. The stalled CephCluster also fails the
-        # HelmRelease, which blocks ~22 dependent Kustomizations.
-        # Data is healthy (265 PGs active+clean, 9/9 OSDs up/in), so the only
-        # thing this check is blocking on is the auth audit.
-        - op: add
-          path: /spec/values/cephClusterSpec/skipUpgradeChecks
-          value: true


### PR DESCRIPTION
Reverts the temporary `skipUpgradeChecks` patch from #2382. Restores the file **byte-for-byte** to its pre-#2382 state.

## The rollout it was for is done

All 9 OSDs went 20.2.2 → 20.2.4, one at a time, in about 14 minutes:

```
9 osds: 9 up, 9 in        265/265 active+clean        0% degraded
ceph versions overall:    20.2.4 = 16 daemons
CephCluster: Ready        HelmRelease: True           Kustomization: True
```

Never more than one OSD down at any point, no stalls, client IO uninterrupted throughout.

## Why this has to go back

`skipUpgradeChecks` is blunt. It does not only step around the CephX audit that stranded this upgrade — it stops Rook checking cluster health before **any** future Ceph version change. Left on, the next Ceph bump would roll the OSDs with no gate at all: degraded PGs, OSDs already down, mons out of quorum would none of them stop it. It was scoped to one rollout deliberately.

During the rollout Rook logged its own reminder every pass:

```
W | op-mon: this is a Ceph upgrade, not performing upgrade checks because skipUpgradeChecks is true
```

## Expected end state

The cluster stays **HEALTH_ERR**, and that is not a regression. The two remaining errors are `AUTH_INSECURE_SERVICE_KEY_TYPE` and `AUTH_INSECURE_SERVICE_TICKETS`; both clear only with the CephX key rotation, which is tracked separately in `docs-notes/ceph-cephx-key-rotation.md`. fairy-k8s01 has sat in exactly this state since 2026-09-06 without issue.

This will not re-stall anything: Rook refuses upgrades on `HEALTH_ERR` only when there is a version mismatch to act on, and there no longer is one — every daemon is on 20.2.4.

Side note: with no 20.2.2 OSDs left, the ordering trap that made rotation impossible here is gone. atlantis is now ready for daemon key rotation whenever we choose to do it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-cluster Flux/Kustomize config change that restores normal Rook upgrade gating; no application or auth logic changes, and the stalled OSD rollout it addressed is complete.
> 
> **Overview**
> Re-enables Rook’s **pre-upgrade health checks** on **atlantis-k8s01** by dropping the temporary HelmRelease patch that set `cephClusterSpec.skipUpgradeChecks: true` (and its inline rationale comments). The Kustomization patch list again only removes `encryptedDevice` from cluster values.
> 
> That workaround was added so OSDs could finish **20.2.2 → 20.2.4** while the cluster was **HEALTH_ERR** from the CephX audit; with all daemons on **20.2.4**, leaving `skipUpgradeChecks` would let future Ceph version rolls proceed with no health gate. **HEALTH_ERR** from `AUTH_INSECURE_*` may remain until key rotation; that is expected and should not re-block upgrades while versions are aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197e414f83ffefc7a6f18d5b0a2b6188360c3091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->