### PR TITLE
feat(rook-ceph): rotate daemon CephX keys and mute the un-clearable warnings

### DIFF
--- a/kubernetes/apps/storage/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/storage/rook-ceph/cluster/helmrelease.yaml
@@ -75,6 +75,37 @@ spec:
             enabled: true
           - name: rook
             enabled: true
+      security:
+        cephx:
+          # Ceph 20.2.4 added the CVE-2025-30156 CephX audit, which flags every
+          # legacy `aes` key. Rotating the daemon keys (mon/mgr/osd/mds/rgw) to
+          # aes256k clears the two HEALTH_ERR checks. Bump keyGeneration again
+          # to force a future rotation.
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+          csi:
+            # aes256k on the CSI path needs a Linux 7.0+ kernel on every node to
+            # mount existing volumes. Talos is still on the 6.18 series as of
+            # v1.14 (6.18.48), so the CSI keys have to stay on aes for now.
+            keyType: aes
+          # Deliberately NOT setting allowedCiphers: [aes256k] — restricting the
+          # cluster to aes256k while the CSI keys are still aes makes the cluster
+          # unavailable.
+      healthCheck:
+        # These four cannot clear until the CSI keys move to aes256k, which is
+        # gated on the kernel above. Left unmuted they mask real warnings, and a
+        # permanently-warning cluster trains you to ignore `ceph health`.
+        # Revisit all of this when Talos ships a 7.0+ kernel.
+        muteHealthWarning:
+          AUTH_INSECURE_CLIENT_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED:
+            policy: mute
+          AUTH_INSECURE_KEYS_CREATABLE:
+            policy: mute
+          AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE:
+            policy: mute
       storage:
         encryptedDevice: true
     # default values, remove once I don't need a single node cluster


### PR DESCRIPTION
Finishes the [CVE-2025-30156](https://docs.ceph.com/en/latest/security/CVE-2025-30156/) CephX migration as far as our kernels allow. Follows #2382/#2383, which unstranded atlantis's OSDs.

## What clears

Both clusters have been `HEALTH_ERR` since 2026-09-06:

```
[ERR] AUTH_INSECURE_SERVICE_KEY_TYPE    13 auth service entities (mon/mgr/osd/mds/rgw)
[ERR] AUTH_INSECURE_SERVICE_TICKETS     atlantis only
```

Rotating daemon keys to `aes256k` clears these. **This is only possible now** — a 20.2.2 OSD predates `aes256k` entirely, and rotation invalidates the old key immediately, so doing this before #2382 would have broken atlantis's OSDs outright.

## What can't clear: the kernel gate

Rook requires **Linux 7.0+ on every node** before CSI keys may use `aes256k`, or existing volumes can't be mounted. Talos is still on 6.18 — **v1.14 ships 6.18.48** — so this isn't a wait-for-next-release situation. CSI keys stay `aes`, and the pin is now explicit rather than relying on Rook's default.

That strands four warnings indefinitely:

```
AUTH_INSECURE_CLIENT_KEY_TYPE
AUTH_INSECURE_KEYS_ALLOWED
AUTH_INSECURE_KEYS_CREATABLE
AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE
```

They're muted via `healthCheck.muteHealthWarning`. A cluster that warns permanently is one whose warnings stop getting read, and these would mask a real one. **Unmute them alongside the CSI rotation** when the kernel allows it.

## Deliberately not done

`allowedCiphers: [aes256k]` is **not** set. Restricting the cluster to `aes256k` while CSI keys are still `aes` causes cluster unavailability, per Rook's docs.

## Blast radius

Rook rolls the Ceph control plane on **both clusters**: mon → mgr → OSD → MDS → RGW, restarting each daemon. Same shape as the OSD roll in #2382 — one daemon at a time, PDBs enforcing one failure domain, pools are `size=3 min_size=2` so data stays readable and writable.

Ceph keeps using the old key type internally for **2–3 hours** after rotation, so `ceph health` takes that long to fully settle. Lingering warnings immediately after are expected, not a failure.

## Verification

CRD support confirmed and the change server-side dry-run accepted on a live cluster:

```
security.cephx      -> {"csi":{"keyType":"aes"},"daemon":{"keyGeneration":2,"keyRotationPolicy":"KeyGeneration"}}
muteHealthWarning   -> 4 entries, policy: mute
```

Current `status.cephx` shows `keyGeneration: 1` on fairy (unset on atlantis), so `2` triggers the rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Triggers CephX daemon key rotation and a rolling restart of core Ceph daemons on both clusters; CSI and volume mounts stay on legacy cipher until the node kernel catches up.
> 
> **Overview**
> Advances **CVE-2025-30156** CephX hardening in the Rook `cephClusterSpec` by rotating **daemon** keys (`keyRotationPolicy: KeyGeneration`, `keyGeneration: 2`) so mon/mgr/osd/mds/rgw move to **aes256k** and the related `HEALTH_ERR` checks can clear.
> 
> **CSI** keys are explicitly pinned to **`aes`** because Talos nodes are still on a **6.18** kernel (aes256k on the mount path needs **7.0+**). **`allowedCiphers: [aes256k]`** is intentionally omitted so the cluster does not become unavailable while CSI stays on aes.
> 
> Four **auth warnings that cannot clear** until CSI can rotate are **muted** via `healthCheck.muteHealthWarning` so persistent noise does not hide real `ceph health` issues; the comments call out revisiting mutes when Talos ships a 7.0+ kernel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c099820464f00b90605967868f19624273089762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->