### PR TITLE
feat(renovate): track Talos against the Image Factory version list

### DIFF
--- a/.renovate/infraPackages.json5
+++ b/.renovate/infraPackages.json5
@@ -11,7 +11,7 @@
     },
     {
       description: "customize talos upgrades",
-      matchPackageNames: ["ghcr.io/siderolabs/installer"],
+      matchPackageNames: ["siderolabs/talos"],
       commitMessagePrefix: "{{semanticCommitType}}(infra/talos):",
       commitMessageTopic: "talos",
       commitMessageAction: "upgrade",
@@ -22,7 +22,7 @@
       matchFileNames: ["kubernetes/clusters/atlantis-k8s01/**"],
       matchPackageNames: [
         "ghcr.io/siderolabs/kubelet",
-        "ghcr.io/siderolabs/installer",
+        "siderolabs/talos",
       ],
       additionalBranchPrefix: "atlantis-k8s01-",
       commitMessageSuffix: "on atlantis-k8s01",
@@ -32,7 +32,7 @@
       matchFileNames: ["kubernetes/clusters/fairy-k8s01/**"],
       matchPackageNames: [
         "ghcr.io/siderolabs/kubelet",
-        "ghcr.io/siderolabs/installer",
+        "siderolabs/talos",
       ],
       additionalBranchPrefix: "fairy-k8s01-",
       commitMessageSuffix: "on fairy-k8s01",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -17,6 +17,10 @@
     ':dependencyDashboard',
     ':semanticCommits',
     ':timezone(America/Chicago)',
+    // Defines the custom.talos-factory datasource, which lists the Talos
+    // versions the Image Factory can actually build. Must come before
+    // infraPackages so our per-cluster commit rules still take precedence.
+    'github>home-operations/renovate-presets//apps/talosFactory.json5#8.1.0',
     'github>nicolerenee/infra//.renovate/infraPackages.json5',
   ],
   rebaseWhen: 'behind-base-branch',

--- a/kubernetes/clusters/atlantis-k8s01/apps/system-upgrade/tuppr-plans.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/system-upgrade/tuppr-plans.yaml
@@ -18,7 +18,7 @@ spec:
     substitute:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
       KUBERNETES_VERSION: v1.37.0
-      # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+      # renovate: datasource=custom.talos-factory depName=siderolabs/talos
       TALOS_VERSION: v1.13.7
   prune: true
   retryInterval: 2m

--- a/kubernetes/clusters/fairy-k8s01/apps/system-upgrade/tuppr-plans.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/system-upgrade/tuppr-plans.yaml
@@ -18,7 +18,7 @@ spec:
     substitute:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
       KUBERNETES_VERSION: v1.37.0
-      # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+      # renovate: datasource=custom.talos-factory depName=siderolabs/talos
       TALOS_VERSION: v1.13.8
   prune: true
   retryInterval: 2m


### PR DESCRIPTION
Switches `TALOS_VERSION` from a docker-tag lookup on `ghcr.io/siderolabs/installer` to the Talos Image Factory's own version list.

```diff
-      # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+      # renovate: datasource=custom.talos-factory depName=siderolabs/talos
       TALOS_VERSION: v1.13.8
```

The factory endpoint is the canonical answer to *"which Talos versions exist"* rather than a proxy for it. It currently returns 105 clean semver entries through `v1.14.0` (plus a `v1.15.0-alpha.0` prerelease, which `config:recommended` ignores as unstable).

## Why the preset is safe here

`custom.talos-factory` is defined by `home-operations/renovate-presets//apps/talosFactory.json5`, pinned to `8.1.0`.

The preset also ships its own custom manager, but it is **inert for us** — I checked both conditions:

| Preset matcher | Our repo |
|---|---|
| `factory\.talos\.dev\/…:(v\S+)` | no `factory.talos.dev` references anywhere |
| `talosVersion:\s*(v?[0-9]…)` under `/talos/` | `talconfig.yaml` has `talosVersion: ${TALOS_VERSION}` — a variable, doesn't start with a digit, won't match |

So the only thing we take from it is the datasource definition. Our existing annotated-dependency custom manager already handles `datasource=… depName=…` comments and picks the value straight out of the `postBuild.substitute` block.

It's extended **before** `infraPackages` deliberately: the preset sets `semanticCommitScope: container` and `commitMessageTopic: {{depName}}` for this datasource, and our rules need to override those.

## The part that would have broken quietly

The dependency name changes from `ghcr.io/siderolabs/installer` → `siderolabs/talos`. **Three** rules in `infraPackages.json5` key on the old name:

- `customize talos upgrades` — the `(infra/talos):` commit prefix
- `seperate infra upgrades on atlantis-k8s01` — branch prefix + suffix
- `seperate infra upgrades on fairy-k8s01` — branch prefix + suffix

Leaving those alone would have kept CI green while silently **merging fairy and atlantis Talos upgrades into one PR** — precisely the per-cluster separation that exists so node-reboot changes go one cluster at a time. All three are updated here.

## Validation

- `.renovaterc.json5` and `.renovate/infraPackages.json5` both parse as JSON5.
- `renovate-config-validator` reports **no new errors**. The three `Invalid configuration option: *.managerFilePatterns` it does report are **pre-existing on `origin/main`** and an artifact of npx resolving Renovate `37.440.7`, which predates `managerFilePatterns` replacing `fileMatch`.

## Expected after merge

The next Talos PR should still read `fix(infra/talos): upgrade talos ( … ) on fairy-k8s01`, on its own branch, separate from atlantis. If it instead appears as `fix(container): update siderolabs/talos` or covers both clusters, the override ordering needs revisiting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only wiring and annotation changes; no runtime cluster upgrade logic is modified, though mis-ordered extends could briefly break per-cluster Talos PR separation.
> 
> **Overview**
> Renovate now bumps **`TALOS_VERSION`** using the **`custom.talos-factory`** datasource (`siderolabs/talos`) instead of Docker tags on **`ghcr.io/siderolabs/installer`**, on both **atlantis-k8s01** and **fairy-k8s01** `tuppr-plans` Kustomizations.
> 
> The repo pulls in **`home-operations/renovate-presets` `talosFactory.json5#8.1.0** before **`infraPackages.json5`** so the factory version list is available while existing per-cluster commit/branch rules still win over the preset defaults.
> 
> **`infraPackages.json5`** rekeys three Talos-related **`matchPackageNames`** rules from **`ghcr.io/siderolabs/installer`** to **`siderolabs/talos`**, preserving **`(infra/talos):`** messaging and separate atlantis vs fairy upgrade PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25be7aa44780379b94998a5cdcc0a236a9e6d2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->