### PR TITLE
feat(atlantis): upgrade Talos to v1.14.0

### DIFF
--- a/kubernetes/clusters/atlantis-k8s01/apps/system-upgrade/tuppr-plans.yaml
+++ b/kubernetes/clusters/atlantis-k8s01/apps/system-upgrade/tuppr-plans.yaml
@@ -19,7 +19,7 @@ spec:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
       KUBERNETES_VERSION: v1.37.0
       # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-      TALOS_VERSION: v1.13.7
+      TALOS_VERSION: v1.14.0
   prune: true
   retryInterval: 2m
   sourceRef:


### PR DESCRIPTION
Takes **atlantis-k8s01 only** from Talos `v1.13.7` → `v1.14.0`. fairy follows once a node here comes back clean.

## Why now

The Kubernetes 1.37.0 upgrade (#2334/#2335) has been failing on both clusters since it merged:

```
automatically detected the lowest Kubernetes version 1.36.3
unsupported upgrade path 1.36->1.37 (from "1.36.3" to "1.37.0")
```

`talosctl` refuses it — Talos 1.13.x doesn't support Kubernetes 1.37. **Nothing is damaged**: it fails at the pre-flight check, no node cordoned, all nodes Ready on v1.36.3. But the `KubernetesUpgrade` CR stays `Failed` until Talos moves.

This also couldn't have been offered before #2385 — Sidero stopped publishing the installer image at that tag:

```
ghcr.io/siderolabs/installer:v1.13.10  → HTTP 200
ghcr.io/siderolabs/installer:v1.14.0   → HTTP 404
```

The old docker datasource was structurally incapable of seeing 1.14. The Factory list has it.

## Machine config is deliberately not regenerated

Talos migrates the on-disk config in place during upgrade. Regenerating instead would mean running **talhelper, which is end-of-life**:

| | |
|---|---|
| talhelper final release | v3.1.17, **2026-08-26** |
| bundled machinery | `v1.14.0-alpha.2` |
| Talos 1.14.0 GA | **2026-09-03** |

Its last build never saw the final 1.14 schema, and our local install is older still (3.1.10). Pushing configs through that is the larger risk. Consequence: `clusterconfig/` in git goes stale against the live nodes until we choose a replacement — tracked separately.

## Verified non-issues

- **etcd metrics moved 2379 → 2383** — we run `kubeEtcd.enabled: false`, nothing scrapes it.
- **`--mode=reboot` removed from `apply-config`** — tuppr uses `talosctl upgrade`.
- **In-tree iSCSI broken under workload isolation** — `sandboxd` defaults **off** for existing clusters and we don't set `SecurityProfileConfig`; democratic-csi is a CSI driver regardless.
- The long v1alpha1 → multi-document list is **deprecations**, not removals in 1.14.

## Watch during rollout

- **`atlantis-compute05`** — tuppr runs `rebootMode: powercycle` and that node has a dead CMOS battery that hangs it at BIOS POST on cold boot. Most likely node to need manual attention.
- **`bond0`** — bond formation has broken before on network-document migration. Talos doing its own in-place migration should be safer than talhelper regenerating it, but it's the thing to check first if a node doesn't come back.
- The `TalosUpgrade` health check gates on `status.ceph.health in ['HEALTH_OK']` — atlantis reached HEALTH_OK after #2384, so the gate is satisfied.

## After this lands

Reset the failed `KubernetesUpgrade` CR with the `tuppr.home-operations.com/reset` annotation (never delete it — that loses history) so k8s 1.37.0 can retry against a supported path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Single-line change triggers an in-cluster Talos OS upgrade (reboot/powercycle) on atlantis nodes, which is critical infrastructure despite the small diff.
> 
> **Overview**
> Bumps the Flux **postBuild** substitute **`TALOS_VERSION`** for **atlantis-k8s01** only from **`v1.13.7`** to **`v1.14.0`**, so tuppr’s **`TalosUpgrade`** plan targets the new installer version and unlocks a supported Talos path for the already-set **`KUBERNETES_VERSION: v1.37.0`**.
> 
> **fairy-k8s01** is unchanged in this diff; rollout there is intentionally deferred until atlantis validates cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d5eedae55920c49dd61e8596e9172770f115af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->