### PR TITLE
fix(gpu): give the operator HelmRelease room and stop rollback retries

### DIFF
--- a/kubernetes/apps/devices/nvidia-gpu-operator/helmrelease.yaml
+++ b/kubernetes/apps/devices/nvidia-gpu-operator/helmrelease.yaml
@@ -22,6 +22,11 @@ spec:
         kind: HelmRepository
         name: nvidia
   interval: 1h
+  # The operator rolls several DaemonSets (dcgm, dcgm-exporter, validators,
+  # feature-discovery) one pod at a time across the GPU nodes. The v26.3.3 ->
+  # v26.7.0 upgrade ran close to Flux's 5m default, and a ClusterPolicy ->
+  # GPUCluster migration is a larger roll still.
+  timeout: 20m
   install:
     crds: CreateReplace
     remediation:
@@ -30,7 +35,12 @@ spec:
     cleanupOnFail: true
     crds: CreateReplace
     remediation:
-      retries: 3
+      # retries: 0 is load-bearing. Flux's default remediation is `rollback`,
+      # and with cleanupOnFail a timeout part-way through a GPU stack roll
+      # would roll back onto a half-migrated state, then retry the whole thing
+      # up to three more times. Hold Failed for a human instead. Same trap as
+      # the rook-ceph and cilium HelmReleases.
+      retries: 0
   values:
     # Talos provides NVIDIA drivers via system extensions
     driver:


### PR DESCRIPTION
Prerequisite for #2391 (DRA via GPU Operator). **Merge this first.**

## Problem

```yaml
interval: 1h           # no explicit timeout -> Flux default 5m
upgrade:
  cleanupOnFail: true
  remediation:
    retries: 3         # default remediation strategy is `rollback`
```

The operator rolls several DaemonSets one pod at a time across the GPU nodes — dcgm, dcgm-exporter, operator-validator, cuda-validator, feature-discovery. Today's v26.3.3 → v26.7.0 upgrade completed, but ran close to 5m; I watched `ClusterPolicy` sit `notReady` on `[state-operator-validation state-dcgm-exporter]` while exporters cycled one at a time.

A `ClusterPolicy` → `GPUCluster` migration tears down one CR's operands and stands up another's — a larger roll than a version bump.

If that overruns 5m, Flux rolls back **a half-migrated GPU stack**, then retries the whole thing three more times. The inference workloads hold ResourceClaims against DeviceClasses that migration is recreating, so thrashing it is the worst case.

## Change

```yaml
timeout: 20m
upgrade:
  remediation:
    retries: 0
```

Same pattern already applied to the rook-ceph HelmRelease (`timeout: 1h`, `retries: 0`) and cilium (`timeout: 20m`, `retries: 0`) for exactly this reason. `retries: 0` holds the release `Failed` for a human rather than auto-rolling-back a partially applied state.

`install.remediation.retries: 3` is left alone — a failed *install* has no half-migrated state to protect.

## Note

This is a Flux-level change only. It alters no chart values and triggers no pod roll.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flux HelmRelease metadata only; no chart value or runtime GPU stack changes.
> 
> **Overview**
> Aligns the NVIDIA **gpu-operator** Flux `HelmRelease` with the same safety pattern used on **cilium** and **rook-ceph**: **`timeout: 20m`** so long GPU stack rolls (DaemonSets + future `ClusterPolicy` → `GPUCluster` migration) are less likely to hit Flux’s **5m** default, and **`upgrade.remediation.retries: 0`** so a timeout does not trigger automatic rollback/retry cycles on a **partially upgraded** stack.
> 
> **Install** remediation stays at **3 retries**; chart **values** are unchanged, so this is Flux behavior only and should not roll pods by itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7346b1a411ee577a0520a70c98954560e49dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->