### PR TITLE
fix(ci): tell flate the clusters serve the DRA DeviceClass API

### DIFF
--- a/.github/workflows/image-pull-extract-pull.yaml
+++ b/.github/workflows/image-pull-extract-pull.yaml
@@ -85,9 +85,17 @@ jobs:
       - name: Gather Images
         run: |
           rc=0
+          # --api-versions declares APIs the real clusters serve but an offline
+          # render cannot discover. Charts that gate on API availability fail
+          # closed otherwise: the GPU Operator refuses to render a GPUCluster CR
+          # with "no resource.k8s.io DeviceClass API is served" unless told
+          # DRA exists. Both clusters run Kubernetes 1.37 and use DRA in anger
+          # (nvidia and intel GPU drivers), so asserting it here matches reality
+          # rather than papering over a gap.
           flate get images \
             --path kubernetes/clusters/${{ inputs.cluster }}/flux \
             --allow-missing-secrets \
+            --api-versions resource.k8s.io/v1/DeviceClass \
             --output json \
             --no-progress > images.json 2> flate.err || rc=$?
 


### PR DESCRIPTION
Prerequisite for #2391. **Merge this first** — #2391 cannot pass `Image Pull` without it.

## Problem

#2391 fails the render gate on both clusters:

```
flate error: reconcile completed with 1 failure(s):
  HelmRelease/gpu-operator/gpu-operator: helm template gpu-operator/gpu-operator:
  execution error at (gpu-operator/templates/validations.yaml:28:3):
  gpuCluster.deployCR=true requires a Kubernetes cluster that supports Dynamic
  Resource Allocation (no resource.k8s.io DeviceClass API is served). When
  rendering offline with 'helm template', pass --api-versions resource.k8s.io/v1/DeviceClass
```

The chart gates on API availability. `flate` renders offline with no cluster to discover from, so the guard fails closed — the chart's own error message names the fix.

## Change

```diff
  flate get images \
    --path kubernetes/clusters/${{ inputs.cluster }}/flux \
    --allow-missing-secrets \
+   --api-versions resource.k8s.io/v1/DeviceClass \
    --output json \
    --no-progress > images.json 2> flate.err || rc=$?
```

`flate` exposes helm's flag directly (`internal/cli/common.go:313`, `--api-versions`/`-a`, comma-separated → `.Capabilities.APIVersions`).

## This asserts a fact, it doesn't silence a check

Both clusters run **Kubernetes 1.37** and DRA is load-bearing:

```
DeviceClasses:  gpu.nvidia.com  mig.nvidia.com  vfio.gpu.nvidia.com
                gpu.intel.com   gpu-vfio.intel.com  rdma.dra.net
                compute-domain-{daemon,default-channel}.nvidia.com
ResourceClaims: inference/minimax ×2, inference/qwen  -> gpu.nvidia.com
                media/emby, home-automation/scrypted  -> gpu.intel.com
```

So declaring `resource.k8s.io/v1/DeviceClass` matches what the clusters actually serve. It is narrowly scoped to that one API — it does not blanket-disable chart capability checks.

Worth noting the failure was reported for **atlantis-k8s01**, which has no gpu-operator pointer at all — consistent with flate's known behaviour of aliasing namespace-less source CRs to the repo root and rendering everything against every cluster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to offline image enumeration; no production deployment or auth/data paths touched.
> 
> **Overview**
> Fixes offline **Image Pull** renders where the GPU Operator Helm chart fails closed because `helm template` cannot see cluster APIs.
> 
> The **Gather Images** step now passes **`--api-versions resource.k8s.io/v1/DeviceClass`** to `flate get images`, matching Kubernetes 1.37 clusters that actually use DRA (NVIDIA/Intel GPU drivers). Inline comments document why this is an assertion of real capability, not a blanket bypass of chart checks.
> 
> **Scope:** CI workflow only; no runtime cluster or app manifest changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 363421faa55a64f64af3025e6eb325f5dc44866e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->