### PR TITLE
Revert "feat(gpu): manage the NVIDIA DRA driver through the GPU Operator"

### DIFF
--- a/kubernetes/apps/devices/dra-driver-nvidia-gpu/helmrelease.yaml
+++ b/kubernetes/apps/devices/dra-driver-nvidia-gpu/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# DRA Driver for NVIDIA GPUs. Project moved from the NVIDIA org to
+# kubernetes-sigs/dra-driver-nvidia-gpu in v0.4.0 and the chart was
+# renamed from nvidia-dra-driver-gpu to dra-driver-nvidia-gpu. We adopt
+# the new name everywhere (fresh deploy, no in-cluster state to preserve).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dra-driver-nvidia-gpu
+spec:
+  interval: 1h
+  url: oci://registry.k8s.io/dra-driver-nvidia/charts/dra-driver-nvidia-gpu
+  ref:
+    tag: 0.4.1
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dra-driver-nvidia-gpu
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dra-driver-nvidia-gpu
+  interval: 1h
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Talos installs drivers via system extensions under /usr/local
+    nvidiaDriverRoot: /usr/local
+    gpuResourcesEnabledOverride: true
+    resources:
+      gpus:
+        enabled: true
+    # Chart's default affinity already targets GPU nodes via NFD/GPU
+    # operator labels (pci-10de.present, nvidia.com/gpu.present, etc.) —
+    # no nodeSelector needed. We only add a toleration for the
+    # nvidia.com/gpu:NoSchedule taint that Talos sets on DGX nodes.
+    kubeletPlugin:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule

--- a/kubernetes/apps/devices/dra-driver-nvidia-gpu/kustomization.yaml
+++ b/kubernetes/apps/devices/dra-driver-nvidia-gpu/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/devices/nvidia-gpu-operator/helmrelease.yaml
+++ b/kubernetes/apps/devices/nvidia-gpu-operator/helmrelease.yaml
@@ -42,22 +42,6 @@ spec:
       # the rook-ceph and cilium HelmReleases.
       retries: 0
   values:
-    # Manage the DRA driver through the GPU Operator (26.7.0+) instead of the
-    # standalone dra-driver-nvidia-gpu chart. The operator drives this from a
-    # GPUCluster CR, which is mutually exclusive with ClusterPolicy — the chart
-    # fails the render if both are enabled — so ClusterPolicy is turned off in
-    # the same change.
-    #
-    # GPUCluster is a slimmer CR than ClusterPolicy: it covers draDriver, dcgm,
-    # dcgmExporter, hostPaths and daemonsets only. Driver, toolkit and device
-    # plugin are not part of it, which suits us — Talos supplies the driver and
-    # container toolkit via system extensions, and the device plugin is replaced
-    # by DRA. Those values stay false to satisfy the chart's own validations.
-    clusterPolicy:
-      deployCR: false
-    gpuCluster:
-      deployCR: true
-
     # Talos provides NVIDIA drivers via system extensions
     driver:
       enabled: false

--- a/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/dra-driver-nvidia-gpu.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/dra-driver-nvidia-gpu.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.freckle.systems/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dra-driver-nvidia-gpu
+  namespace: &namespace gpu-operator
+spec:
+  targetNamespace: *namespace
+  dependsOn:
+    - name: nvidia-gpu-operator
+      namespace: gpu-operator
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/devices/dra-driver-nvidia-gpu
+  interval: 2m
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true

--- a/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/kustomization.yaml
+++ b/kubernetes/clusters/fairy-k8s01/apps/gpu-operator/kustomization.yaml
@@ -8,3 +8,4 @@ components:
   - ../../../../components/flux-post-build-variables
 resources:
   - ./nvidia-gpu-operator.yaml
+  - ./dra-driver-nvidia-gpu.yaml


### PR DESCRIPTION
Reverts #2391. **The GPU Operator's DRA driver does not support a non-standard driver root, so it cannot work on Talos.**

## What broke

Talos ships the NVIDIA driver at `/usr/local`. `hostPaths.driverInstallDir: /usr/local` reaches the `GPUCluster` CR, and the operator passes it to its own `driver-validation` init container as `DRIVER_INSTALL_DIR` — but it never reaches the `gpus` / `compute-domains` containers that generate CDI specs. They fall back to driver root `/`:

```
CDI specs on the node, split by generator:
  nvidia.yaml                              good-5 bad-0   <- toolkit
  k8s.gpu.nvidia.com-claim_a4788f1f...     good-5 bad-0   <- standalone driver
  k8s.compute-domain...device_base.yaml    bad-5  good-0  <- operator driver
  k8s.gpu.nvidia.com-claim_7006066f...     bad-5  good-0  <- operator driver
  k8s.gpu.nvidia.com-claim_c953800b...     bad-5  good-0  <- operator driver

on disk:  /bin/nvidia-cuda-mps-control            DOES NOT EXIST
          /usr/local/bin/nvidia-cuda-mps-control  exists
```

Any pod consuming an operator-generated spec dies at container init:

```
failed to fulfil mount request: open /bin/nvidia-cuda-mps-control: no such file or directory
```

That took out all three dcgm-exporters and all three DRA validators, and would have taken out MiniMax and Qwen the moment either restarted — they survived only on a stale, correct claim spec from the old driver.

## Why it isn't fixable from the CRD

The standalone chart's `nvidiaDriverRoot` does three coordinated things:

1. `NVIDIA_DRIVER_ROOT` on an **init container** running `kubelet-plugin-prestart.sh`
2. mounts the driver root's **parent** (`/usr`) with `mountPropagation: HostToContainer`
3. mounts the driver root itself at `/driver-root`

The operator's DaemonSet has a different init container (`driver-validation`) and no prestart script. `GPUCluster` exposes only `env`/`healthcheck`/`resources` on the kubelet plugins.

**Tested:** setting `NVIDIA_DRIVER_ROOT=/usr/local` via `draDriver.{gpus,computeDomains}.kubeletPlugin.env` — it did not change detection (`devRoot=/host` still) and **regressed the two nodes that were working**, taking the cluster from 2/3 plugins healthy to 0/3. Reverted.

This looks like an upstream gap for non-FHS driver roots, worth raising with NVIDIA.

## What this restores / keeps

- **Restores:** standalone `dra-driver-nvidia-gpu` and its DeviceClasses
- **Keeps:** gpu-operator v26.7.0 (#2318) and the HelmRelease hardening from #2392 (`timeout: 20m`, `retries: 0`)
- #2313 (standalone DRA 0.4.1 → 0.5.0) becomes relevant again rather than obsolete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GPU DRA is delivered (operator vs standalone DaemonSet) on a critical GPU path; misconfiguration could break CDI specs and GPU workloads until the standalone driver is healthy.
> 
> **Overview**
> Reverts GPU Operator–managed DRA and **deploys the standalone `dra-driver-nvidia-gpu` chart again** (OCI `0.4.1` from `registry.k8s.io`), wired into `fairy-k8s01` via a Flux `Kustomization` that depends on `nvidia-gpu-operator`.
> 
> The new HelmRelease sets **`nvidiaDriverRoot: /usr/local`** for Talos system-extension drivers, enables GPU resource claims, and adds a **`nvidia.com/gpu` NoSchedule toleration** on the kubelet plugin for DGX taints. The GPU Operator release **drops `GPUCluster` / disabled `ClusterPolicy`** so it no longer owns the DRA driver; it still runs with driver, toolkit, and device plugin disabled and **`hostPaths.driverInstallDir: /usr/local`**, keeping v26.7.0 and existing upgrade hardening (`timeout: 20m`, `retries: 0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266f03ee7be818f24b6e3d3bbdba57b39ae548d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->