### PR TITLE
fix(renovate): use semver-coerced for the Jellyfin image

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -48,6 +48,19 @@
   },
   packageRules: [
     {
+      // Jellyfin publishes a two-segment tag (12.0) while we are pinned to a
+      // three-segment one (10.11.11). Renovate's default `docker` versioning
+      // requires both to have the same number of segments —
+      // lib/modules/versioning/docker/index.ts isCompatible():
+      //   parsed1.release.length === parsed2.release.length
+      // — so 12.0 is silently filtered out and no PR is ever opened. There is
+      // no 12.0.0 tag upstream to match instead. semver-coerced normalises
+      // "12.0" to "12.0.0", which compares correctly and keeps working if
+      // Jellyfin goes back to three segments.
+      matchPackageNames: ['ghcr.io/jellyfin/jellyfin'],
+      versioning: 'semver-coerced',
+    },
+    {
       // When the kubernetes-sigs/gateway-api tag in
       // scripts/vendor-gateway-api-crds.sh is bumped, re-run the vendor
       // script to regenerate the CRD YAML files in the same PR. Requires


### PR DESCRIPTION
Jellyfin 12.0 released ~5 days ago and Renovate never opened a PR. **Nothing was misconfigured** — it's a version-shape mismatch.

## Root cause

Renovate's default `docker` versioning only accepts a candidate with the **same number of version segments** as the current pin — [`lib/modules/versioning/docker/index.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/versioning/docker/index.ts):

```ts
override isCompatible(version: string, current: string): boolean {
  return !!(
    parsed1 && parsed2 &&
    parsed1.suffix === parsed2.suffix &&
    parsed1.release.length === parsed2.release.length   // <-- here
  );
}
```

```
current:   10.11.11  -> release.length = 3
candidate: 12.0      -> release.length = 2   => incompatible, filtered
```

Confirmed against the registry — upstream only published the two-segment tag:

```
ghcr.io/jellyfin/jellyfin:12.0     -> 200
ghcr.io/jellyfin/jellyfin:12.0.0   -> 404
```

So there is no three-segment tag to match instead.

## Ruled out

- **Not a blocked PR** — the dashboard's "PR Closed (Blocked)" section contains only #2336 (vllm); no Jellyfin PR has ever existed for 12.0.
- **Not major-blocking** — `docker:enableMajor` is set.
- **Not a missing dependency** — Jellyfin appears under "Detected Dependencies" in dashboard #135, so Renovate sees it fine.
- **Consistent with history** — every prior bump (`10.11.8 → 10.11.10 → 10.11.11`) was three-segment to three-segment, which is why this never surfaced before.

## Fix

```json5
{
  matchPackageNames: ['ghcr.io/jellyfin/jellyfin'],
  versioning: 'semver-coerced',
}
```

`semver-coerced` normalises `"12.0"` → `"12.0.0"` ([docs](https://docs.renovatebot.com/modules/versioning/semver-coerced/)), which orders correctly against `10.11.11` and keeps working if Jellyfin returns to three segments. Scoped to this image only, so `docker` versioning remains the default everywhere else.

## Note

This only makes the update *visible*. **10.11 → 12.0 is a major jump on the primary media server** and the resulting PR should not be merged as routine — the upgrade is being researched separately, particularly whether the library database migration is reversible.

`renovate-config-validator` reports no new errors (the three `*.managerFilePatterns` ones are pre-existing on `main` and an artifact of npx resolving Renovate 37).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate configuration only; it does not change the running Jellyfin version, though it may later surface a major upgrade PR that needs separate review.
> 
> **Overview**
> Renovate was **not opening update PRs** for `ghcr.io/jellyfin/jellyfin` after upstream moved to a **two-segment** tag (`12.0`) while the cluster pin stays **three-segment** (`10.11.11`). Default **`docker` versioning** treats those shapes as incompatible, so `12.0` is dropped before a PR is created (and there is no `12.0.0` tag to match).
> 
> This adds a **scoped `packageRules` entry** for that image only, setting **`versioning: 'semver-coerced'`** so tags like `12.0` normalize for semver comparison and future bumps can surface. Other Docker dependencies keep the default `docker` versioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57cfd661fb6ca777b4f09eead5f456cda905e245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->